### PR TITLE
[Design/Feat] 공통 컴포넌트_헤더, 하단 탭바 스타일링 및 기능 구현

### DIFF
--- a/my-app/src/components/common/FormHeader.jsx
+++ b/my-app/src/components/common/FormHeader.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import Button from './Button';
+import Theme from '../../styles/Theme';
+import IconBack from '../../assets/Icon-Back.png';
+
+const Container = styled.header`
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 4.8rem;
+  background-color: ${Theme.WHITE};
+  padding: 0 2rem;
+  z-index: 99;
+  border-bottom: 1px solid ${Theme.BORDER};
+`;
+
+const SButton = styled.button`
+  background-color: ${Theme.WHITE};
+  width: 2.4rem;
+  height: 2.4rem;
+  img {
+    width: 100%;
+    height: 100%;
+    margin-right: 0.6rem;
+  }
+`;
+
+const PageTitle = styled.h2`
+  font-size: 1.8rem;
+  padding-top: 0.4rem;
+`;
+
+const Menu = styled.div`
+  display: flex;
+`;
+
+function FormHeader({ title, onClick }) {
+  const navigate = useNavigate();
+  const handlePageBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <Container>
+      <Menu>
+        <SButton onClick={handlePageBack}>
+          <img src={IconBack} alt='뒤로가기' />
+        </SButton>
+        <PageTitle>{title}</PageTitle>
+      </Menu>
+      <Button text='등록' size='sm' onClick={onClick} />
+    </Container>
+  );
+}
+
+export default FormHeader;

--- a/my-app/src/components/common/Header.jsx
+++ b/my-app/src/components/common/Header.jsx
@@ -6,7 +6,7 @@ import IconHeartOff from '../../assets/Icon-Heart-off.png';
 import IconMore from '../../assets/Icon-More.png';
 
 const Container = styled.header`
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   right: 0;
@@ -30,7 +30,7 @@ const Menu = styled.div`
   display: flex;
 `;
 
-const PageTitle = styled.div`
+const PageTitle = styled.h2`
   font-size: 1.8rem;
   padding-top: 0.4rem;
 `;

--- a/my-app/src/components/common/Header.jsx
+++ b/my-app/src/components/common/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import Theme from '../../styles/Theme';
 import IconBack from '../../assets/Icon-Back.png';
 
@@ -48,12 +49,17 @@ function Header({
   altTwo,
   onClickTwo,
 }) {
+  const navigate = useNavigate();
+  const handlePageBack = () => {
+    navigate(-1);
+  };
+
   return (
     <Container>
       <Menu>
         {isHome ? null : (
-          <SButton>
-            <img src={IconBack} alt='뒤로가기' />{' '}
+          <SButton onClick={handlePageBack}>
+            <img src={IconBack} alt='뒤로가기' />
           </SButton>
         )}
         {title && <PageTitle>{title}</PageTitle>}

--- a/my-app/src/components/common/Header.jsx
+++ b/my-app/src/components/common/Header.jsx
@@ -2,14 +2,19 @@ import React from 'react';
 import styled from 'styled-components';
 import Theme from '../../styles/Theme';
 import IconBack from '../../assets/Icon-Back.png';
+import IconHeartOff from '../../assets/Icon-Heart-off.png';
+import IconMore from '../../assets/Icon-More.png';
 
-const HeaderContainer = styled.header`
+const Container = styled.header`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   height: 4.8rem;
-  background-color: pink;
+  background-color: ${Theme.WHITE};
   padding: 0 2rem;
   z-index: 99;
   border-bottom: 1px solid ${Theme.BORDER};
@@ -17,15 +22,31 @@ const HeaderContainer = styled.header`
   img {
     width: 2.4rem;
     height: 2.4rem;
-    background-color: red;
+    margin-right: 0.6rem;
   }
+`;
+
+const Menu = styled.div`
+  display: flex;
+`;
+
+const PageTitle = styled.div`
+  font-size: 1.8rem;
+  padding-top: 0.4rem;
 `;
 
 function Header() {
   return (
-    <HeaderContainer>
-      <img src={IconBack} alt='뒤로가기' />
-    </HeaderContainer>
+    <Container>
+      <Menu>
+        <img src={IconBack} alt='뒤로가기' />
+        <PageTitle>음료</PageTitle>
+      </Menu>
+      <Menu>
+        <img src={IconHeartOff} alt='' />
+        <img src={IconMore} alt='' />
+      </Menu>
+    </Container>
   );
 }
 

--- a/my-app/src/components/common/Header.jsx
+++ b/my-app/src/components/common/Header.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import Theme from '../../styles/Theme';
 import IconBack from '../../assets/Icon-Back.png';
-import IconHeartOff from '../../assets/Icon-Heart-off.png';
-import IconMore from '../../assets/Icon-More.png';
 
 const Container = styled.header`
   position: sticky;
@@ -18,10 +16,15 @@ const Container = styled.header`
   padding: 0 2rem;
   z-index: 99;
   border-bottom: 1px solid ${Theme.BORDER};
+`;
 
+const SButton = styled.button`
+  background-color: ${Theme.WHITE};
+  width: 2.4rem;
+  height: 2.4rem;
   img {
-    width: 2.4rem;
-    height: 2.4rem;
+    width: 100%;
+    height: 100%;
     margin-right: 0.6rem;
   }
 `;
@@ -35,19 +38,44 @@ const PageTitle = styled.h2`
   padding-top: 0.4rem;
 `;
 
-function Header() {
+function Header({
+  isHome,
+  title,
+  rightIconOne,
+  altOne,
+  onClickOne,
+  rightIconTwo,
+  altTwo,
+  onClickTwo,
+}) {
   return (
     <Container>
       <Menu>
-        <img src={IconBack} alt='뒤로가기' />
-        <PageTitle>음료</PageTitle>
+        {isHome ? null : (
+          <SButton>
+            <img src={IconBack} alt='뒤로가기' />{' '}
+          </SButton>
+        )}
+        {title && <PageTitle>{title}</PageTitle>}
       </Menu>
       <Menu>
-        <img src={IconHeartOff} alt='' />
-        <img src={IconMore} alt='' />
+        {rightIconOne && (
+          <SButton onClick={onClickOne}>
+            <img src={rightIconOne} alt={altOne} />
+          </SButton>
+        )}
+        {rightIconTwo && (
+          <SButton onClick={onClickTwo}>
+            <img src={rightIconTwo} alt={altTwo} />
+          </SButton>
+        )}
       </Menu>
     </Container>
   );
 }
+
+Header.defaultProps = {
+  isHome: false,
+};
 
 export default Header;

--- a/my-app/src/components/common/NavBar.jsx
+++ b/my-app/src/components/common/NavBar.jsx
@@ -2,13 +2,18 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Theme from '../../styles/Theme';
+import IconHome from '../../assets/Icon-Nav-Home-off.png';
+import IconMap from '../../assets/Icon-Nav-Map-off.png';
+import IconWrite from '../../assets/Icon-Nav-Write-off.png';
+import IconLiked from '../../assets/Icon-Nav-Heart-off.png';
+import IconMyPage from '../../assets/Icon-Nav-_Mypage-off.png';
 
-const NavBarContaier = styled.nav`
+const Container = styled.nav`
   position: fixed;
   bottom: 0;
   width: 100%;
   height: 6rem;
-  background-color: pink;
+  background-color: ${Theme.WHITE};
   border-top: 1px solid ${Theme.BORDER};
   padding: 0 2rem;
 
@@ -19,34 +24,49 @@ const NavBarContaier = styled.nav`
   }
 
   li {
-    height: 6rem;
     width: 6.2rem;
-    background-color: orange;
+    height: 6rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: ${Theme.DISABLED_BTN_FONT};
+  }
+
+  img {
+    width: 2.4rem;
+    height: 2.4rem;
+    margin-bottom: 0.2rem;
   }
 `;
 
 function NavBar() {
   return (
-    <NavBarContaier>
+    <Container>
       <ul>
         <li>
+          <img src={IconHome} alt='' />
           <Link to={'/home'}>홈</Link>
         </li>
         <li>
+          <img src={IconMap} alt='' />
           <Link to={'/map'}>지도</Link>
         </li>
         <li>
+          <img src={IconWrite} alt='' />
           <Link to={'/upload'}>기록</Link>
         </li>
         <li>
+          <img src={IconLiked} alt='' />
           <Link to={'/likeposts'}>좋아요</Link>
         </li>
         <li>
+          <img src={IconMyPage} alt='' />
           <Link to={'/mypage'}>마이</Link>
         </li>
       </ul>
       <Link to=''></Link>
-    </NavBarContaier>
+    </Container>
   );
 }
 

--- a/my-app/src/components/common/NavBar.jsx
+++ b/my-app/src/components/common/NavBar.jsx
@@ -3,10 +3,15 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Theme from '../../styles/Theme';
 import IconHome from '../../assets/Icon-Nav-Home-off.png';
+import IconHomeActive from '../../assets/Icon-Nav-Home-on.png';
 import IconMap from '../../assets/Icon-Nav-Map-off.png';
+import IconMapActive from '../../assets/Icon-Nav-Map-on.png';
 import IconWrite from '../../assets/Icon-Nav-Write-off.png';
+import IconWriteActive from '../../assets/Icon-Nav-Write-on.png';
 import IconLiked from '../../assets/Icon-Nav-Heart-off.png';
+import IconLikedActive from '../../assets/Icon-Nav-Heart-on.png';
 import IconMyPage from '../../assets/Icon-Nav-_Mypage-off.png';
+import IconMyPageActive from '../../assets/Icon-Nav-_Mypage-on.png';
 
 const Container = styled.nav`
   position: fixed;
@@ -40,28 +45,50 @@ const Container = styled.nav`
   }
 `;
 
-function NavBar() {
+function NavBar({ page }) {
   return (
     <Container>
       <ul>
         <li>
-          <img src={IconHome} alt='' />
+          {page === 'home' ? (
+            <img src={IconHomeActive} alt='메인 페이지 바로가기' />
+          ) : (
+            <img src={IconHome} alt='메인 페이지 바로가기' />
+          )}
           <Link to={'/home'}>홈</Link>
         </li>
         <li>
-          <img src={IconMap} alt='' />
+          {page === 'map' ? (
+            <img src={IconMapActive} alt='지도 페이지 바로가기' />
+          ) : (
+            <img src={IconMap} alt='지도 페이지 바로가기' />
+          )}
           <Link to={'/map'}>지도</Link>
         </li>
         <li>
-          <img src={IconWrite} alt='' />
+          {page === 'upload' ? (
+            <img src={IconWriteActive} alt='게시글 작성 페이지 바로가기' />
+          ) : (
+            <img src={IconWrite} alt='게시글 작성 페이지 바로가기' />
+          )}
+
           <Link to={'/upload'}>기록</Link>
         </li>
         <li>
-          <img src={IconLiked} alt='' />
+          {page === 'liked' ? (
+            <img src={IconLikedActive} alt='좋아요 페이지 바로가기' />
+          ) : (
+            <img src={IconLiked} alt='좋아요 페이지 바로가기' />
+          )}
           <Link to={'/likeposts'}>좋아요</Link>
         </li>
         <li>
-          <img src={IconMyPage} alt='' />
+          {page === 'myPage' ? (
+            <img src={IconMyPageActive} alt='마이 페이지 바로가기' />
+          ) : (
+            <img src={IconMyPage} alt='마이 페이지 바로가기' />
+          )}
+
           <Link to={'/mypage'}>마이</Link>
         </li>
       </ul>

--- a/my-app/src/components/common/SearchHeader.jsx
+++ b/my-app/src/components/common/SearchHeader.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import Theme from '../../styles/Theme';
+import IconBack from '../../assets/Icon-Back.png';
+import Button from '../../components/common/Button';
+
+const Container = styled.header`
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 4.8rem;
+  background-color: ${Theme.WHITE};
+  padding: 0 2rem;
+  z-index: 99;
+  border-bottom: 1px solid ${Theme.BORDER};
+  gap: 1rem;
+`;
+
+const SButton = styled.button`
+  background-color: ${Theme.WHITE};
+  width: 2.4rem;
+  height: 2.4rem;
+  img {
+    width: 100%;
+    height: 100%;
+    margin-right: 0.6rem;
+  }
+`;
+
+const SInput = styled.input`
+  width: 25.4rem;
+  height: 3.2rem;
+  padding: 1rem 0 1rem 1.4rem;
+  border: 1px solid ${Theme.BORDER};
+  border-radius: 3.2rem;
+
+  &:focus {
+    /* 임시로 설정 */
+    border: 1px solid ${Theme.MAIN_FONT};
+    outline: none;
+  }
+`;
+
+function SearchHeader({
+  isHome,
+  title,
+  rightIconOne,
+  altOne,
+  onClickOne,
+  rightIconTwo,
+  altTwo,
+  onClickTwo,
+}) {
+  const navigate = useNavigate();
+  const handlePageBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <Container>
+      <SButton onClick={handlePageBack}>
+        <img src={IconBack} alt='뒤로가기' />
+      </SButton>
+      <SInput type='text' placeholder='검색어를 입력하세요.' />
+      <Button size='sm' text='검색' />
+    </Container>
+  );
+}
+
+export default SearchHeader;

--- a/my-app/src/pages/Home/Home.jsx
+++ b/my-app/src/pages/Home/Home.jsx
@@ -1,17 +1,27 @@
 import React from 'react';
+import styled from 'styled-components';
 import Button from '../../components/common/Button';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
+
+const Wrapper = styled.main`
+  height: calc(100vh - 10.8rem);
+  display: flex;
+  flex-direction: column;
+  height: fit-content;
+`;
 
 function Home() {
   return (
     <>
       <Header />
-      <Button size='lg' text='회원가입' />
-      <Button size='md' text='회원가입(md)' />
-      <Button size='ms' text='회원가입(ms)' />
-      <Button size='sm' text='등록' />
-      <Button size='profile' text='프로필수정' />
+      <Wrapper>
+        <Button size='lg' text='회원가입' />
+        <Button size='md' text='회원가입(md)' />
+        <Button size='ms' text='회원가입(ms)' />
+        <Button size='sm' text='등록' />
+        <Button size='profile' text='프로필수정' />
+      </Wrapper>
       <NavBar />
     </>
   );

--- a/my-app/src/styles/GlobalStyle.js
+++ b/my-app/src/styles/GlobalStyle.js
@@ -37,7 +37,7 @@ ${reset}
 }
 body {
   overflow-x: hidden;
-
+  min-height: 100vh;
 }
 
 button {


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 헤더, 하단 탭바 스타일링
- [x] 스타일 : 헤더, 하단 탭바 기능 구현


### 🙏🏻 기대 결과
- 하단 탭바 및 헤더 스타일링 
- 하단 탭바 및 헤더 props 작업
- 하단 탭바 현재 페이지인 경우 따른 filled 아이콘 표시 
- 헤더 뒤로가기 버튼 기능 구현 

- Header컴포넌트 기능 분리하여 SearchHeader 컴포넌트 구현 
- Header컴포넌트 기능 분리하여 FormHeader 컴포넌트 구현 

### 📸 스크린샷

전체 화면 (헤더+하단 탭바)

<img width="343" alt="스크린샷 2023-02-10 21 53 03" src="https://user-images.githubusercontent.com/95897068/218097076-cf38e57e-efdf-4c9c-8763-b514e16ebbb6.png">

FormHeader 

<img width="343" alt="스크린샷 2023-02-12 21 32 35" src="https://user-images.githubusercontent.com/95897068/218311272-1adf9135-faa6-45f1-99bb-f3ffc79133fc.png">

SearchHeader

<img width="343" alt="스크린샷 2023-02-12 21 30 52" src="https://user-images.githubusercontent.com/95897068/218311184-ed7ca0ea-ed48-4dfc-982c-d4f285c5cbfc.png">

SearchHeader-Active(Focus) 

<img width="343" alt="스크린샷 2023-02-12 21 34 38" src="https://user-images.githubusercontent.com/95897068/218311356-158950c4-772d-4797-949b-b5477f6e6ce1.png">

### 🙂 전달사항
- 공통 컴포넌트를 Header.jsx 하나로 처리하려니 props많아져서 이질적인 헤더는 따로 분리했습니다. Header, SearchHeader, FormHeader 
SearchHeader -> CO-S1, CO-S2
FormHeader -> CO-PW (기록하기 페이지) 
Header -> 홈과 나머지 페이지 
- 하단 탭바 사용하실 때 page props에 url명 넘겨주어서 active 시켜 사용해주시면 됩니다!

- 피그마에 검색창 active되었을 때의 디자인 예시가 없어서 아래와 같이 임의로 설정해놨습니다. 이 부분은 결정나면 추후에 변경하겠습니다~ !
<img width="343" alt="스크린샷 2023-02-12 21 34 38" src="https://user-images.githubusercontent.com/95897068/218311356-158950c4-772d-4797-949b-b5477f6e6ce1.png">


### 😉 Issue Number
close : #8
