### PR TITLE
[Design/Feat] 공통 컴포넌트_바텀 시트, 컨펌 모달 스타일링 및 기능 구현

### DIFF
--- a/my-app/.eslintrc.json
+++ b/my-app/.eslintrc.json
@@ -1,3 +1,13 @@
 {
-  "extends": ["react-app", "react-app/jest", "naver", "prettier"]
+  "extends": [
+    "react-app",
+    "react-app/jest",
+    "naver",
+    "prettier",
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
+  "rules": {
+    "react/prop-types": "off"
+  }
 }

--- a/my-app/src/components/common/Button.jsx
+++ b/my-app/src/components/common/Button.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
 import Theme from '../../styles/Theme';
 // import Theme from '../../styles/Theme';
@@ -23,7 +24,7 @@ const setSize = (size) => {
         }
 
         &:disabled {
-          color: ${Theme.DISABLED_FONT}
+          color: ${Theme.DISABLED_FONT};
           background-color: #ffe58e;
         }
       `;
@@ -40,7 +41,7 @@ const setSize = (size) => {
         }
 
         &:disabled {
-          color: ${Theme.DISABLED_FONT}
+          color: ${Theme.DISABLED_FONT};
           background-color: #ffe58e;
         }
       `;
@@ -57,7 +58,7 @@ const setSize = (size) => {
         }
 
         &:disabled {
-          color: ${Theme.DISABLED_FONT}
+          color: ${Theme.DISABLED_FONT};
           background-color: #ffe58e;
         }
       `;
@@ -74,7 +75,7 @@ const setSize = (size) => {
         }
 
         &:disabled {
-          color: ${Theme.DISABLED_FONT}
+          color: ${Theme.DISABLED_FONT};
           background-color: #ffe58e;
         }
       `;

--- a/my-app/src/components/common/Header.jsx
+++ b/my-app/src/components/common/Header.jsx
@@ -26,7 +26,10 @@ const SButton = styled.button`
   img {
     width: 100%;
     height: 100%;
-    margin-right: 0.6rem;
+  }
+
+  & + button {
+    margin-left: 0.6rem;
   }
 `;
 

--- a/my-app/src/components/common/NavBar.jsx
+++ b/my-app/src/components/common/NavBar.jsx
@@ -16,7 +16,9 @@ import IconMyPageActive from '../../assets/Icon-Nav-_Mypage-on.png';
 const Container = styled.nav`
   position: fixed;
   bottom: 0;
-  width: 100%;
+  left: 0;
+  right: 0;
+  z-index: 99;
   height: 6rem;
   background-color: ${Theme.WHITE};
   border-top: 1px solid ${Theme.BORDER};
@@ -89,7 +91,7 @@ function NavBar({ page }) {
             <img src={IconMyPage} alt='마이 페이지 바로가기' />
           )}
 
-          <Link to={'/mypage'}>마이</Link>
+          <Link to={'/mypage'}>내 정보</Link>
         </li>
       </ul>
       <Link to=''></Link>

--- a/my-app/src/components/modal/BottomSheet.jsx
+++ b/my-app/src/components/modal/BottomSheet.jsx
@@ -1,57 +1,58 @@
 import React from 'react';
 import styled from 'styled-components';
+import Theme from '../../styles/Theme';
+
+const Background = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 0.2;
+  z-index: 99;
+  background-color: black;
+`;
+
+const Box = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background: ${Theme.WHITE};
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+  padding: 3.6rem 0 0.5rem 0;
+`;
+
+const CloseHandler = styled.button`
+  width: 5rem;
+  height: 0.4rem;
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 0.5rem;
+  background-color: ${Theme.SHADOW_BORDER};
+  &::after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 2.5rem;
+    margin-top: -1rem;
+  }
+`;
+
+const Contents = styled.button`
+  background-color: ${Theme.WHITE};
+  text-align: left;
+  padding: 1.3rem 0 1.4rem 2.7rem;
+`;
 
 function BottomSheet() {
-  const Background = styled.div`
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    opacity: 0.2;
-    z-index: 99;
-    background-color: black;
-  `;
-
-  const Box = styled.div`
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 999;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    background: white;
-    border-top-left-radius: 1rem;
-    border-top-right-radius: 1rem;
-    padding: 3.6rem 0 0.5rem 0;
-  `;
-
-  const CloseHandler = styled.button`
-    width: 5rem;
-    height: 0.4rem;
-    position: absolute;
-    top: 10%;
-    left: 50%;
-    transform: translateX(-50%);
-    border-radius: 0.5rem;
-    background-color: #dbdbdb;
-    &::after {
-      content: '';
-      display: block;
-      width: 100%;
-      height: 2.5rem;
-      margin-top: -1rem;
-    }
-  `;
-
-  const Contents = styled.button`
-    background-color: white;
-    text-align: left;
-    padding: 1.3rem 0 1.4rem 2.7rem;
-  `;
-
   return (
     <>
       <Background />

--- a/my-app/src/components/modal/BottomSheet.jsx
+++ b/my-app/src/components/modal/BottomSheet.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function BottomSheet() {
+  const Background = styled.div`
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0.2;
+    z-index: 99;
+    background-color: black;
+  `;
+
+  const Box = styled.div`
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 999;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    background: white;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+    padding: 3.6rem 0 0.5rem 0;
+  `;
+
+  const CloseHandler = styled.button`
+    width: 5rem;
+    height: 0.4rem;
+    position: absolute;
+    top: 10%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: 0.5rem;
+    background-color: #dbdbdb;
+    &::after {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 2.5rem;
+      margin-top: -1rem;
+    }
+  `;
+
+  const Contents = styled.button`
+    background-color: white;
+    text-align: left;
+    padding: 1.3rem 0 1.4rem 2.7rem;
+  `;
+
+  return (
+    <>
+      <Background />
+      <Box>
+        <CloseHandler />
+        <Contents>수정</Contents>
+        <Contents>삭제</Contents>
+      </Box>
+    </>
+  );
+}
+
+export default BottomSheet;

--- a/my-app/src/components/modal/BottomSheet.jsx
+++ b/my-app/src/components/modal/BottomSheet.jsx
@@ -52,12 +52,12 @@ const Contents = styled.button`
   padding: 1.3rem 0 1.4rem 2.7rem;
 `;
 
-function BottomSheet({ onClickEdit, onClickDelete }) {
+function BottomSheet({ onClickClose, onClickEdit, onClickDelete }) {
   return (
     <>
-      <Background />
+      <Background onClick={onClickClose} />
       <Box>
-        <CloseHandler />
+        <CloseHandler onClick={onClickClose} />
         <Contents onClick={onClickEdit}>수정</Contents>
         <Contents onClick={onClickDelete}>삭제</Contents>
       </Box>

--- a/my-app/src/components/modal/BottomSheet.jsx
+++ b/my-app/src/components/modal/BottomSheet.jsx
@@ -52,14 +52,14 @@ const Contents = styled.button`
   padding: 1.3rem 0 1.4rem 2.7rem;
 `;
 
-function BottomSheet() {
+function BottomSheet({ onClickEdit, onClickDelete }) {
   return (
     <>
       <Background />
       <Box>
         <CloseHandler />
-        <Contents>수정</Contents>
-        <Contents>삭제</Contents>
+        <Contents onClick={onClickEdit}>수정</Contents>
+        <Contents onClick={onClickDelete}>삭제</Contents>
       </Box>
     </>
   );

--- a/my-app/src/components/modal/ConfirmModal.jsx
+++ b/my-app/src/components/modal/ConfirmModal.jsx
@@ -59,15 +59,15 @@ const BtnRed = styled.button`
   background-color: ${Theme.WHITE};
 `;
 
-function ConfirmModal() {
+function ConfirmModal({ msg, leftBtnMsg, leftOnclick, rightBtnMsg, rightOnclick }) {
   return (
     <>
       <Background />
       <Box>
-        <Msg>좋아요 목록에서 삭제할까요?</Msg>
+        <Msg>{msg}</Msg>
         <Btns>
-          <Btn>취소</Btn>
-          <BtnRed>삭제</BtnRed>
+          <Btn onClick={leftOnclick}>{leftBtnMsg}</Btn>
+          <BtnRed onClick={rightOnclick}>{rightBtnMsg}</BtnRed>
         </Btns>
       </Box>
     </>

--- a/my-app/src/components/modal/ConfirmModal.jsx
+++ b/my-app/src/components/modal/ConfirmModal.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function ConfirmModal() {
+  const Background = styled.div`
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0.2;
+    z-index: 99;
+    background-color: black;
+  `;
+
+  const Box = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: absolute;
+    z-index: 999;
+    top: 50%;
+    left: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    width: 252px;
+    height: 110px;
+    padding-top: 2.5rem;
+    background-color: tomato;
+    border-radius: 1rem;
+  `;
+
+  const Msg = styled.p`
+    text-align: center;
+    font-weight: 700;
+    font-size: 1.6rem;
+  `;
+
+  const Btns = styled.div`
+    display: flex;
+    /* position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0; */
+    width: 100%;
+    border-top: 1px solid black;
+  `;
+
+  const Btn = styled.button`
+    width: 50%;
+    padding: 1.5rem 0 1.5rem;
+    overflow: hidden;
+    border-bottom-left-radius: 1rem;
+    border-right: 1px solid black;
+  `;
+
+  const BtnRed = styled.button`
+    width: 50%;
+    padding: 1.5rem 0 1.5rem;
+    overflow: hidden;
+    color: red;
+    border-bottom-right-radius: 1rem;
+  `;
+
+  return (
+    <>
+      <Background />
+      <Box>
+        <Msg>기록을 삭제할까요?</Msg>
+        <Btns>
+          <Btn>취소</Btn>
+          <BtnRed>삭제</BtnRed>
+        </Btns>
+      </Box>
+    </>
+  );
+}
+
+export default ConfirmModal;

--- a/my-app/src/components/modal/ConfirmModal.jsx
+++ b/my-app/src/components/modal/ConfirmModal.jsx
@@ -31,7 +31,7 @@ const Box = styled.div`
 
 const Msg = styled.p`
   text-align: center;
-  font-weight: 700;
+  font-family: LINESeedKR-bd;
   font-size: 1.6rem;
 `;
 
@@ -59,10 +59,10 @@ const BtnRed = styled.button`
   background-color: ${Theme.WHITE};
 `;
 
-function ConfirmModal({ msg, leftBtnMsg, leftOnclick, rightBtnMsg, rightOnclick }) {
+function ConfirmModal({ onClickClose, msg, leftBtnMsg, leftOnclick, rightBtnMsg, rightOnclick }) {
   return (
     <>
-      <Background />
+      <Background onClick={onClickClose} />
       <Box>
         <Msg>{msg}</Msg>
         <Btns>

--- a/my-app/src/components/modal/ConfirmModal.jsx
+++ b/my-app/src/components/modal/ConfirmModal.jsx
@@ -1,71 +1,70 @@
 import React from 'react';
 import styled from 'styled-components';
+import Theme from '../../styles/Theme';
+
+const Background = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 0.2;
+  z-index: 99;
+  background-color: black;
+`;
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: absolute;
+  z-index: 999;
+  top: 50%;
+  left: 50%;
+  transform: translate3d(-50%, -50%, 0);
+  width: 25.2rem;
+  height: 11rem;
+  padding-top: 2.5rem;
+  background-color: ${Theme.WHITE};
+  border-radius: 1rem;
+`;
+
+const Msg = styled.p`
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.6rem;
+`;
+
+const Btns = styled.div`
+  display: flex;
+  width: 100%;
+  border-top: 1px solid ${Theme.SHADOW_BORDER};
+`;
+
+const Btn = styled.button`
+  width: 50%;
+  padding: 1.5rem 0 1.5rem;
+  overflow: hidden;
+  border-bottom-left-radius: 1rem;
+  border-right: 1px solid ${Theme.SHADOW_BORDER};
+  background-color: ${Theme.WHITE};
+`;
+
+const BtnRed = styled.button`
+  width: 50%;
+  padding: 1.5rem 0 1.5rem;
+  overflow: hidden;
+  color: ${Theme.ERROR};
+  border-bottom-right-radius: 1rem;
+  background-color: ${Theme.WHITE};
+`;
 
 function ConfirmModal() {
-  const Background = styled.div`
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    opacity: 0.2;
-    z-index: 99;
-    background-color: black;
-  `;
-
-  const Box = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    position: absolute;
-    z-index: 999;
-    top: 50%;
-    left: 50%;
-    transform: translate3d(-50%, -50%, 0);
-    width: 252px;
-    height: 110px;
-    padding-top: 2.5rem;
-    background-color: tomato;
-    border-radius: 1rem;
-  `;
-
-  const Msg = styled.p`
-    text-align: center;
-    font-weight: 700;
-    font-size: 1.6rem;
-  `;
-
-  const Btns = styled.div`
-    display: flex;
-    /* position: absolute;
-    bottom: 0;
-    right: 0;
-    left: 0; */
-    width: 100%;
-    border-top: 1px solid black;
-  `;
-
-  const Btn = styled.button`
-    width: 50%;
-    padding: 1.5rem 0 1.5rem;
-    overflow: hidden;
-    border-bottom-left-radius: 1rem;
-    border-right: 1px solid black;
-  `;
-
-  const BtnRed = styled.button`
-    width: 50%;
-    padding: 1.5rem 0 1.5rem;
-    overflow: hidden;
-    color: red;
-    border-bottom-right-radius: 1rem;
-  `;
-
   return (
     <>
       <Background />
       <Box>
-        <Msg>기록을 삭제할까요?</Msg>
+        <Msg>좋아요 목록에서 삭제할까요?</Msg>
         <Btns>
           <Btn>취소</Btn>
           <BtnRed>삭제</BtnRed>

--- a/my-app/src/hooks/useToggle.jsx
+++ b/my-app/src/hooks/useToggle.jsx
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+function useToggle(initialValue = false) {
+  const [toggle, setToggle] = useState(initialValue);
+  const onToggle = () => {
+    setToggle(!toggle);
+  };
+
+  return [toggle, onToggle];
+}
+
+export default useToggle;

--- a/my-app/src/pages/Map/index.jsx
+++ b/my-app/src/pages/Map/index.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
-import * as S from './style'
+import * as S from './style';
 
 function Map() {
   return (
-  <>
-    <Header />
-    <S.Container />
-    <NavBar />
-  </>
-)
-};
+    <>
+      <Header />
+      <S.Container />
+      <NavBar />
+    </>
+  );
+}
 
 export default Map;


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 모달에 쓰일 useToggle 커스텀훅 생성, 바텀시트와 컨펌모달 props 
- [x] 스타일 : 바텀 시트, 컨펌 모달 스타일링 
- [x] 버그 수정 : 헤더, 하단탭바 스타일 수정

### 🙏🏻 기대 결과

- hooks 디렉터리 만들어서 useToggle 커스텀훅 생성
- 스타일링 오류 수정 : 헤더 아이콘 간격, 하단 탭바 좌측 뜨는 현상 고침 

### 📸 스크린샷




📌 컨펌 모달

<img width="320" alt="스크린샷 2023-02-15 12 16 32" src="https://user-images.githubusercontent.com/95897068/218918198-4096542e-8919-4fba-ad66-199226b3c032.png">



📌 바텀시트


https://user-images.githubusercontent.com/95897068/218927298-ff7833ab-2898-4075-8b73-28ce59464734.mov



### 🙂 전달사항
- 바텀시트가 쓰이는 곳이 한 곳이길래 바텀시트의 수정 삭제 항목은 child로 설정하지 않고 남겨두었음 

- 바텀시트 close같은 경우 상단 핸들바 + 배경을 클릭해도 닫히게 구현, 가상요소를 추가해 상단 핸들바의 클릭 범위 늘림 
<img width="320" alt="스크린샷 2023-02-15 12 20 57" src="https://user-images.githubusercontent.com/95897068/218918740-c4ce8b81-f01f-4d26-bcd6-09af360f9885.png">

### 😉 Issue Number
close : #10
