### PR TITLE
[Design] 태그 모아보기_마크업/스타일 구현

### DIFF
--- a/my-app/src/pages/Hashtag/Hashtag.jsx
+++ b/my-app/src/pages/Hashtag/Hashtag.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import Header from '../../components/common/Header';
+import NavBar from '../../components/common/NavBar';
 
 function Hashtag() {
-  return <div>Hashtag</div>;
+  return (
+    <>
+      <Header title='태그 모아보기' />
+
+      <NavBar />
+    </>
+  );
 }
 
 export default Hashtag;

--- a/my-app/src/pages/Hashtag/Hashtag.jsx
+++ b/my-app/src/pages/Hashtag/Hashtag.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
+import * as S from './style';
 
 function Hashtag() {
   return (
     <>
       <Header title='태그 모아보기' />
-
+      <S.Container>
+        <S.TagList>
+          <S.Tag>#달아요요오호</S.Tag>
+          <S.Tag>#다시먹을것</S.Tag>
+          <S.Tag>#마따</S.Tag>
+          <S.Tag>#또먹</S.Tag>
+        </S.TagList>
+      </S.Container>
       <NavBar />
     </>
   );

--- a/my-app/src/pages/Hashtag/style.js
+++ b/my-app/src/pages/Hashtag/style.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import Theme from '../../styles/Theme';
+
+export const Container = styled.div`
+  padding: 4.8rem 0 6rem;
+`;
+
+export const TagList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  width: 100%;
+  padding: 2.6rem 0;
+`;
+
+export const Tag = styled.li`
+  padding: 0.5rem 1rem;
+  height: 2.7rem;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  color: ${Theme.WHITE};
+  border-radius: 3rem;
+  background-color: ${Theme.SUB_ORANGE};
+`;


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [X] 스타일 : 태그 모아보기 페이지 마크업 및 스타일 구현
- [ ] 리팩토링 : 
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 

### 🙏🏻 기대 결과
- 피그마 디자인 구현

### 📸 스크린샷
**모바일뷰**
![hashtag](https://user-images.githubusercontent.com/104605709/218964355-eb88e093-40fc-4b5f-ab10-f667b84b0e3b.gif)

**웹뷰**
<img width="941" alt="1" src="https://user-images.githubusercontent.com/104605709/218964427-a5165572-064a-4338-a5de-382162991195.png">


### 🙂 전달사항
- 게시글 상세페이지의 태그 css 코드와 현 페이지의 태그 코드가 상이한 부분이 있어 정리 필요합니다.
- 파이어베이스에서 데이터를 가져올 수 있을 때 map으로 데이터를 받아올 수 있도록 코드 리팩토링 예정입니다.
- 추후 태그 컬러 랜덤적용 예정입니다.

### 😉 Issue Number
close : #6
