### PR TITLE
[Design] PostCard컴포넌트_간단한 반응형 작업

### DIFF
--- a/my-app/src/components/common/PostCard.jsx
+++ b/my-app/src/components/common/PostCard.jsx
@@ -7,7 +7,7 @@ import IconStarOn from '../../assets/Icon-star-on.png';
 const PostCardBox = styled.div`
   position: relative;
   display: flex;
-  width: 35rem;
+  width: 100%;
   height: 18.4rem;
   border-radius: 1rem;
   box-shadow: 1px 1px 6px 2px ${Theme.SHADOW_BORDER};


### PR DESCRIPTION
width: 100%

### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 스타일 : PostCard 컴포넌트 가로 반응형으로 수정 


### 🙏🏻 기대 결과
- 다양한 모바일 환경 대응 

### 📸 스크린샷

가장 좁은 화면 (아이폰SE) 
<img width="362" alt="스크린샷 2023-02-22 18 27 50" src="https://user-images.githubusercontent.com/95897068/220578579-ce61177e-2f2a-4eff-b175-0e7d7a86a724.png">

넓은화면 ( 가로 768 ) 

<img width="591" alt="스크린샷 2023-02-22 18 27 28" src="https://user-images.githubusercontent.com/95897068/220578484-801af144-7126-4854-b0b6-30cbcbb6e4ad.png">

### 🙂 전달사항

한 줄 고쳤습니다ㅋㅎㅎ 

### 😉 Issue Number
close : #51
