### PR TITLE
[Feat] 로그인 페이지_로그인 기능 구현

### DIFF
--- a/my-app/src/hooks/useLogin.jsx
+++ b/my-app/src/hooks/useLogin.jsx
@@ -1,0 +1,38 @@
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useSetRecoilState } from 'recoil';
+import { authState } from '../atom/authRecoil';
+import { appAuth } from '../firebase';
+
+export default function useLogin() {
+  const [error, setError] = useState(null);
+  const [isPending, setIsPending] = useState(false);
+  const setAuth = useSetRecoilState(authState);
+  const navigate = useNavigate();
+
+  const login = (email, password) => {
+    setError(null);
+    setIsPending(true);
+
+    signInWithEmailAndPassword(appAuth, email, password)
+      .then((userCredential) => {
+        const user = userCredential.user;
+
+        setAuth(user);
+        setError(null);
+        setIsPending(false);
+        navigate('/home');
+
+        if (!user) {
+          throw new Error('로그인에 실패했습니다.');
+        }
+      })
+      .catch((err) => {
+        setError(err.message);
+        setIsPending(false);
+      });
+  };
+
+  return { error, isPending, login };
+}

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -2,12 +2,15 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './style';
 import Button from '../../components/common/Button';
 import InputWithLabel from '../../components/common/InputWithLabel';
+import useLogin from '../../hooks/useLogin';
 
 function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoginAllow, setIsLoginAllow] = useState(null);
+  const [loginError, setLoginError] = useState('');
   const [btnDisabled, setBtnDisabled] = useState(true);
+  const { error, login } = useLogin();
   const emailRef = useRef(null);
 
   const handleEmailChange = useCallback((e) => {
@@ -27,10 +30,21 @@ function Login() {
     }
   }, [email, password]);
 
+  useEffect(() => {
+    if (error) {
+      setIsLoginAllow(false);
+      setBtnDisabled(true);
+      setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
+      emailRef.current.focus();
+    } else {
+      setLoginError('');
+    }
+  }, [error]);
+
   const handleLoginSubmit = useCallback(
     (e) => {
       e.preventDefault();
-      console.log(email, password);
+      login(email, password);
     },
     [email, password],
   );
@@ -59,6 +73,7 @@ function Login() {
           placeholder='비밀번호를 입력하세요.'
           onChange={handlePasswordChange}
           isLoginAllow={isLoginAllow}
+          errorMessage={loginError}
         />
         <Button size='lg' text='로그인' btnDisabled={btnDisabled} />
       </S.Form>

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -1,24 +1,66 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './style';
 import Button from '../../components/common/Button';
+import InputWithLabel from '../../components/common/InputWithLabel';
 
 function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoginAllow, setIsLoginAllow] = useState(null);
+  const [btnDisabled, setBtnDisabled] = useState(true);
+  const emailRef = useRef(null);
+
+  const handleEmailChange = useCallback((e) => {
+    setEmail(e.target.value);
+  }, []);
+
+  const handlePasswordChange = useCallback((e) => {
+    setPassword(e.target.value);
+  }, []);
+
+  useEffect(() => {
+    if (!!email.length && !!password.length) {
+      setIsLoginAllow(true);
+      setBtnDisabled(false);
+    } else {
+      setBtnDisabled(true);
+    }
+  }, [email, password]);
+
+  const handleLoginSubmit = useCallback(
+    (e) => {
+      e.preventDefault();
+      console.log(email, password);
+    },
+    [email, password],
+  );
+
   return (
     <S.Container>
       <S.HeaderContainer>
         <S.Title>로그인</S.Title>
       </S.HeaderContainer>
-      <S.Form>
-        <S.InputContainer>
-          <S.Label>이메일</S.Label>
-          <S.Input type='email' placeholder='이메일을 입력하세요.' required />
-        </S.InputContainer>
-        <S.InputContainer>
-          <S.Label>비밀번호</S.Label>
-          <S.Input type='password' placeholder='비밀번호를 입력하세요.' required />
-          <S.ErrorMessage>이메일과 비밀번호가 일치하지 않습니다.</S.ErrorMessage>
-        </S.InputContainer>
-        <Button size='lg' text='로그인' />
+      <S.Form onSubmit={handleLoginSubmit}>
+        <InputWithLabel
+          id='userEmail'
+          labelText='이메일'
+          type='email'
+          value={email}
+          placeholder='이메일을 입력하세요.'
+          onChange={handleEmailChange}
+          ref={emailRef}
+          isLoginAllow={isLoginAllow}
+        />
+        <InputWithLabel
+          id='userPassword'
+          labelText='비밀번호'
+          type='password'
+          value={password}
+          placeholder='비밀번호를 입력하세요.'
+          onChange={handlePasswordChange}
+          isLoginAllow={isLoginAllow}
+        />
+        <Button size='lg' text='로그인' btnDisabled={btnDisabled} />
       </S.Form>
       <S.SignUpLink to='/signup'>이메일로 회원가입</S.SignUpLink>
     </S.Container>

--- a/my-app/src/pages/Login/style.js
+++ b/my-app/src/pages/Login/style.js
@@ -23,43 +23,6 @@ export const Form = styled.form`
   gap: 3rem;
 `;
 
-export const InputContainer = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-`;
-
-export const Label = styled.label`
-  margin-bottom: 0.8rem;
-  font-family: 'LINESeedKR-Bd';
-  font-size: 1.4rem;
-  color: ${Theme.MAIN_GRAY};
-`;
-
-export const Input = styled.input`
-  border: none;
-  border-bottom: 1px solid ${Theme.BORDER};
-  padding: 0.4rem 0;
-  outline: none;
-
-  &::placeholder {
-    color: ${Theme.PLACEHOLDER};
-  }
-
-  &:focus {
-    border-bottom: 1px solid ${Theme.MAIN};
-  }
-`;
-
-export const ErrorMessage = styled.p`
-  position: absolute;
-  top: 5.4rem;
-  font-family: 'LINESeedKR-Rg';
-  font-size: 1.2rem;
-  color: ${Theme.ERROR};
-  display: none;
-`;
-
 export const SignUpLink = styled(Link)`
   display: block;
   margin-top: 2.2rem;


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 로그인 기능 구현
- [ ] 스타일 : 
- [x] 리팩토링 : InputWithLabel 컴포넌트 적용 
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 입력란 모두 한 글자 이상 작성 시 로그인 버튼 활성화
- 이메일, 비밀번호 입력 가능 글자 수는 30자로 제한
- 로그인 시도할 때 이메일, 비밀번호 일치하지 않을 경우 이메일, 비밀번호 border 색상 변화, 비밀번호 입력란 아 에러 메세지 띄우며 이메일 입력란 focus 됨
- 로그인 성공 시 home으로 이동
- 로그인 된 유저 정보는 authState에 저장

### 📸 스크린샷
![로그인기능구현1](https://user-images.githubusercontent.com/83122749/221403609-50f69ebc-e7ef-429f-84e5-3035d4de1198.gif)
![로그인기능구현2](https://user-images.githubusercontent.com/83122749/221403613-6b1ec940-4f4e-4b32-b1aa-b55e5b92d019.gif)


### 🙂 전달사항
- 스토리 보드에  '이메일과 비밀번호의 유효성 검사가 모두 통과하면 로그인 버튼이 활성화된다.'라고 작성되어 있는데, 이메일과 비밀번호 모두 한 글자 이상 입력 시 유효성 검사 통과되는 것으로 기능 구현하였습니다.
- 다만 온전한 이메일 형식을 작성하지 않은 채로 로그인 시도하면 두 번째 이미지와 같이 '@를 포함'해서 작성하라는 안내 문구가 나옵니다. 이 안내 문구를 안 나오게 하는 게 좋을지, 아니면 처음부터 이메일 형식으로 작성해야 유효성 검사 통과되도록 구현할지 고민입니다.
- push하고 보니 에러 메세지 뜬 후 다시 작성할 때 border error 색상이 없어지네요! 수정하겠습니다.

### 😉 Issue Number
close : #57
