### PR TITLE
[Feat] 로그인 페이지_유효성 검사 코드 수정

### DIFF
--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -7,6 +7,8 @@ import useLogin from '../../hooks/useLogin';
 function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [isEmailValid, setIsEmailValid] = useState(false);
+  const [isPasswordValid, setIsPasswordValid] = useState(false);
   const [isLoginAllow, setIsLoginAllow] = useState(null);
   const [loginError, setLoginError] = useState('');
   const [btnDisabled, setBtnDisabled] = useState(true);
@@ -15,10 +17,23 @@ function Login() {
 
   const handleEmailChange = useCallback((e) => {
     setEmail(e.target.value);
+
+    const emailRegExp =
+      /^[A-Za-z0-9_]+[A-Za-z0-9]*[@]{1}[A-Za-z0-9]+[A-Za-z0-9]*[.]{1}[A-Za-z]{2,3}$/;
+
+    if (!emailRegExp.test(e.target.value)) {
+      setIsEmailValid(false);
+    } else {
+      setIsEmailValid(true);
+    }
   }, []);
 
   const handlePasswordChange = useCallback((e) => {
     setPassword(e.target.value);
+
+    if (e.target.value) {
+      setIsPasswordValid(true);
+    }
   }, []);
 
   useEffect(() => {
@@ -32,12 +47,10 @@ function Login() {
 
   useEffect(() => {
     if (error) {
-      setIsLoginAllow(false);
       setBtnDisabled(true);
+      setIsLoginAllow(false);
       setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
       emailRef.current.focus();
-    } else {
-      setLoginError('');
     }
   }, [error]);
 

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -33,13 +33,19 @@ function Login() {
 
     if (e.target.value) {
       setIsPasswordValid(true);
+    } else {
+      setIsPasswordValid(false);
     }
   }, []);
 
   useEffect(() => {
-    if (!!email.length && !!password.length) {
-      setIsLoginAllow(true);
+    if (isEmailValid && isPasswordValid) {
       setBtnDisabled(false);
+      setIsLoginAllow(true);
+
+      if (error) {
+        setIsLoginAllow(false);
+      }
     } else {
       setBtnDisabled(true);
     }


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 이메일 유효성 검사 코드 수정
- [ ] 스타일 : 
- [x] 리팩토링 : 로그인 실패 후(이메일, 비밀번호 불일치) 에러 보더 색상 계속 유지되도록 수정
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 이메일은 이메일 형식으로 작성, 비밀번호는 한 글자 이상 작성 시 로그인 시도할 수 있음
- 이메일, 비밀번호 일치하지 않아 로그인 실패한 경우 다음 로그인 성공 때까지 에러 보더 색상 유지됨

### 📸 스크린샷
![로그인유효성수정](https://user-images.githubusercontent.com/83122749/224529433-e195c5c4-4c43-4358-a282-1a04e3b81a17.gif)


### 🙂 전달사항

### 😉 Issue Number
close : #61
