### PR TITLE
[Feat] 메인 페이지_라우터 기능, firebase 데이터 불러오기

### DIFF
--- a/my-app/src/components/home/CategoryCard/index.jsx
+++ b/my-app/src/components/home/CategoryCard/index.jsx
@@ -1,9 +1,22 @@
 import React from 'react';
+import { useNavigate } from 'react-router';
 import * as S from './style';
 
-function CategoryCard({ Icon, title, count, onClickCard }) {
+function CategoryCard({ Icon, title, count }) {
+  const navigate = useNavigate();
+
+  const onClickCard = () => {
+    navigate('/post', {
+      state: title,
+    });
+  };
+
   return (
-    <S.Container onClick={() => onClickCard()}>
+    <S.Container
+      onClick={() => {
+        onClickCard();
+      }}
+    >
       <S.Count>{count}</S.Count>
       <S.ImgContainer>
         <S.CategoryImg src={Icon} alt='' />

--- a/my-app/src/components/home/CategoryCard/index.jsx
+++ b/my-app/src/components/home/CategoryCard/index.jsx
@@ -3,11 +3,7 @@ import * as S from './style';
 
 function CategoryCard({ Icon, title, count, onClickCard }) {
   return (
-    <S.Container
-      onClick={() => {
-        onClickCard();
-      }}
-    >
+    <S.Container onClick={() => onClickCard()}>
       <S.Count>{count}</S.Count>
       <S.ImgContainer>
         <S.CategoryImg src={Icon} alt='' />

--- a/my-app/src/components/home/CategoryCard/index.jsx
+++ b/my-app/src/components/home/CategoryCard/index.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import * as S from './style';
 
-function CategoryCard({ Icon, title, count }) {
+function CategoryCard({ Icon, title, count, onClickCard }) {
   return (
-    <S.Container>
+    <S.Container
+      onClick={() => {
+        onClickCard();
+      }}
+    >
       <S.Count>{count}</S.Count>
       <S.ImgContainer>
         <S.CategoryImg src={Icon} alt='' />

--- a/my-app/src/components/home/CategoryCard/style.js
+++ b/my-app/src/components/home/CategoryCard/style.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import Theme from '../../../styles/Theme';
 
-export const Container = styled.button`
+export const Container = styled(Link)`
   position: relative;
   display: flex;
   align-items: center;

--- a/my-app/src/components/home/CategoryCard/style.js
+++ b/my-app/src/components/home/CategoryCard/style.js
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import Theme from '../../../styles/Theme';
 
-export const Container = styled(Link)`
+export const Container = styled.div`
   position: relative;
   display: flex;
   align-items: center;
@@ -14,6 +13,8 @@ export const Container = styled(Link)`
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.14);
   font-family: 'LINESeedKR-Bd';
   background-color: ${Theme.WHITE};
+
+  cursor: pointer;
 `;
 
 export const Count = styled.p`

--- a/my-app/src/pages/Home/Home.jsx
+++ b/my-app/src/pages/Home/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -6,21 +7,16 @@ import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard/CategoryCard';
 import PostCard from '../../components/common/PostCard';
-import ConfirmModal from '../../components/modal/ConfirmModal';
-import Portal from '../../components/modal/Potal';
-import useToggle from '../../hooks/useToggle';
 
 function Home() {
-  const [isModalOpen, setIsModalOpen] = useToggle();
-
   return (
     <>
       <Header
         isHome
         rightChild={
           <>
-            <S.HashBtn onClick={setIsModalOpen} />
-            <S.SearchBtn />
+            <S.HashLink to='/hashtag' />
+            <S.SearchLink to='/search' />
           </>
         }
       />
@@ -51,8 +47,6 @@ function Home() {
         </section>
       </S.Container>
       <NavBar page='home' />
-
-      <Portal>{isModalOpen ? <ConfirmModal onClickClose={setIsModalOpen} /> : null}</Portal>
     </>
   );
 }

--- a/my-app/src/pages/Home/Home.jsx
+++ b/my-app/src/pages/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -6,8 +6,22 @@ import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard/CategoryCard';
 import PostCard from '../../components/common/PostCard';
+import { firestore } from '../../firebase';
 
 function Home() {
+  console.log(firestore.collection('user'));
+
+  useEffect(() => {
+    firestore
+      .collection('user')
+      .get()
+      .then((result) => {
+        result.forEach((doc) => {
+          console.log(doc.data());
+        });
+      });
+  }, []);
+
   return (
     <>
       <Header

--- a/my-app/src/pages/Home/Home.jsx
+++ b/my-app/src/pages/Home/Home.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -33,8 +32,8 @@ function Home() {
         <section>
           <S.SubTitle>곽두팔이님의 기록 앨범</S.SubTitle>
           <S.CategoryCards>
-            <CategoryCard title={'음료'} Icon={DrinkIcon} count={'102'} />
-            <CategoryCard title={'디저트'} Icon={DessertIcon} count={'300+'} />
+            <CategoryCard to='/post' title={'음료'} Icon={DrinkIcon} count={'102'} />
+            <CategoryCard to='/post' title={'디저트'} Icon={DessertIcon} count={'300+'} />
           </S.CategoryCards>
         </section>
         <section>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { authState } from '../../atom/authRecoil';
@@ -9,7 +10,7 @@ import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
-import CategoryCard from '../../components/home/CategoryCard/CategoryCard';
+import CategoryCard from '../../components/home/CategoryCard';
 import PostCard from '../../components/common/PostCard';
 
 function Home() {
@@ -18,6 +19,8 @@ function Home() {
   const [postCount, setPostCount] = useState();
   const [drinkCount, setDrinkCount] = useState(0);
   const [dessertCount, setdessertCount] = useState(0);
+
+  const navigate = useNavigate();
 
   const cards = [
     {
@@ -57,6 +60,12 @@ function Home() {
       });
   }, []);
 
+  const onClickCard = () => {
+    navigate('/post', {
+      state: { ...cards },
+    });
+  };
+
   return (
     <>
       <Header
@@ -87,6 +96,7 @@ function Home() {
                 title={card.title}
                 Icon={card.icon}
                 count={card.count}
+                onClickCard={onClickCard}
               />
             ))}
           </S.CategoryCards>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -20,8 +20,6 @@ function Home() {
   const [drinkCount, setDrinkCount] = useState(0);
   const [dessertCount, setdessertCount] = useState(0);
 
-  const navigate = useNavigate();
-
   const cards = [
     {
       categoryId: 'drink',
@@ -61,13 +59,6 @@ function Home() {
       });
   }, []);
 
-  const onClickCard = () => {
-    console.log('onClickCard 실행');
-    navigate('/post', {
-      state: { ...cards },
-    });
-  };
-
   return (
     <>
       <Header
@@ -98,7 +89,6 @@ function Home() {
                 title={card.title}
                 Icon={card.icon}
                 count={card.count}
-                onClickCard={onClickCard}
               />
             ))}
           </S.CategoryCards>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react'; // eslint-disable-line no-unused-vars
-
-import { useRecoilState, useSetRecoilState } from 'recoil'; // eslint-disable-line no-unused-vars
-import { getAuth, onAuthStateChanged } from 'firebase/auth'; // eslint-disable-line no-unused-vars
-import { authState } from '../../atom/authRecoil'; // eslint-disable-line no-unused-vars
-import { appAuth, firestore } from '../../firebase'; // eslint-disable-line no-unused-vars
+import React, { useState, useEffect } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import { authState } from '../../atom/authRecoil';
+import { appAuth, firestore } from '../../firebase';
 
 import * as S from './style';
 import Header from '../../components/common/Header';
@@ -20,6 +19,21 @@ function Home() {
   const [drinkCount, setDrinkCount] = useState(0);
   const [dessertCount, setdessertCount] = useState(0);
 
+  const cards = [
+    {
+      categoryId: 'drink',
+      title: '음료',
+      icon: DrinkIcon,
+      count: drinkCount,
+    },
+    {
+      categoryId: 'dessert',
+      title: '디저트',
+      icon: DessertIcon,
+      count: dessertCount,
+    },
+  ];
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
       setUserState(user);
@@ -28,8 +42,6 @@ function Home() {
 
     return unsubscribe;
   }, []);
-
-  console.log(userState);
 
   useEffect(() => {
     firestore
@@ -69,13 +81,14 @@ function Home() {
         <section>
           <S.SubTitle>{userName}님의 기록 앨범</S.SubTitle>
           <S.CategoryCards>
-            <CategoryCard to='/post/drink' title={'음료'} Icon={DrinkIcon} count={drinkCount} />
-            <CategoryCard
-              to='/post/dessert'
-              title={'디저트'}
-              Icon={DessertIcon}
-              count={dessertCount}
-            />
+            {cards.map((card) => (
+              <CategoryCard
+                key={card.categoryId}
+                title={card.title}
+                Icon={card.icon}
+                count={card.count}
+              />
+            ))}
           </S.CategoryCards>
         </section>
         <section>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import { useRecoilState } from 'recoil';
+import { onAuthStateChanged } from 'firebase/auth';
 import { authState } from '../../atom/authRecoil';
 import { appAuth, firestore } from '../../firebase';
 
@@ -35,15 +34,16 @@ function Home() {
     },
   ];
 
+  console.log(userState);
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
-      console.log(userState);
       setUserState(user);
       setUserName(user.displayName);
     });
 
     return unsubscribe;
-  }, []);
+  }, [setUserState]);
 
   useEffect(() => {
     firestore
@@ -57,6 +57,7 @@ function Home() {
             : setdessertCount(dessertCount + 1);
         });
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -39,6 +39,7 @@ function Home() {
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
+      console.log(userState);
       setUserState(user);
       setUserName(user.displayName);
     });
@@ -61,6 +62,7 @@ function Home() {
   }, []);
 
   const onClickCard = () => {
+    console.log('onClickCard 실행');
     navigate('/post', {
       state: { ...cards },
     });

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // eslint-disable-line no-unused-vars
+
 import { useRecoilState, useSetRecoilState } from 'recoil'; // eslint-disable-line no-unused-vars
 import { getAuth, onAuthStateChanged } from 'firebase/auth'; // eslint-disable-line no-unused-vars
 import { authState } from '../../atom/authRecoil'; // eslint-disable-line no-unused-vars
@@ -16,6 +17,8 @@ function Home() {
   const [userState, setUserState] = useRecoilState(authState);
   const [userName, setUserName] = useState('');
   const [postCount, setPostCount] = useState();
+  const [drinkCount, setDrinkCount] = useState(0);
+  const [dessertCount, setdessertCount] = useState(0);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
@@ -28,17 +31,16 @@ function Home() {
 
   console.log(userState);
 
-  console.log(postCount);
-
   useEffect(() => {
     firestore
       .collection('post')
       .get()
       .then((result) => {
-        console.log(result);
         result.forEach((doc) => {
-          console.log(doc.data());
           setPostCount(doc.data.length);
+          doc.data().theme === '음료'
+            ? setDrinkCount(drinkCount + 1)
+            : setdessertCount(dessertCount + 1);
         });
       });
   }, []);
@@ -67,8 +69,13 @@ function Home() {
         <section>
           <S.SubTitle>{userName}님의 기록 앨범</S.SubTitle>
           <S.CategoryCards>
-            <CategoryCard to='/post' title={'음료'} Icon={DrinkIcon} count={'102'} />
-            <CategoryCard to='/post' title={'디저트'} Icon={DessertIcon} count={'300+'} />
+            <CategoryCard to='/post/drink' title={'음료'} Icon={DrinkIcon} count={drinkCount} />
+            <CategoryCard
+              to='/post/dessert'
+              title={'디저트'}
+              Icon={DessertIcon}
+              count={dessertCount}
+            />
           </S.CategoryCards>
         </section>
         <section>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import { getAuth } from 'firebase/auth'; // eslint-disable-line no-unused-vars
+import { firestore } from '../../firebase'; // eslint-disable-line no-unused-vars
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -6,20 +8,16 @@ import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard/CategoryCard';
 import PostCard from '../../components/common/PostCard';
-import { firestore } from '../../firebase';
 
 function Home() {
-  console.log(firestore.collection('user'));
+  // const [userInfo, setUserInfo] = useState();
+  const [userName, setUserName] = useState();
 
   useEffect(() => {
-    firestore
-      .collection('user')
-      .get()
-      .then((result) => {
-        result.forEach((doc) => {
-          console.log(doc.data());
-        });
-      });
+    const auth = getAuth();
+    const currentUserName = auth.currentUser.displayName;
+
+    setUserName(currentUserName);
   }, []);
 
   return (
@@ -44,7 +42,7 @@ function Home() {
           </S.SectionContainer>
         </section>
         <section>
-          <S.SubTitle>곽두팔이님의 기록 앨범</S.SubTitle>
+          <S.SubTitle>{userName}님의 기록 앨범</S.SubTitle>
           <S.CategoryCards>
             <CategoryCard to='/post' title={'음료'} Icon={DrinkIcon} count={'102'} />
             <CategoryCard to='/post' title={'디저트'} Icon={DessertIcon} count={'300+'} />

--- a/my-app/src/pages/Home/style.js
+++ b/my-app/src/pages/Home/style.js
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
 import Theme from '../../styles/Theme';
 
 import IconTag from '../../assets/Icon-tag.png';
@@ -16,7 +18,7 @@ export const Container = styled.main`
   height: fit-content;
 `;
 
-export const HashBtn = styled.button`
+export const HashLink = styled(Link)`
   position: relative;
   width: 2.4rem;
   height: 2.4rem;
@@ -28,7 +30,7 @@ export const HashBtn = styled.button`
   }
 `;
 
-export const SearchBtn = styled.button`
+export const SearchLink = styled(Link)`
   position: relative;
   width: 2.4rem;
   height: 2.4rem;

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useLocation } from 'react-router';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import IconSearch from '../../assets/Icon-Search.png';
@@ -8,6 +9,10 @@ import * as S from './style';
 function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
+
+  const location = useLocation();
+
+  console.log('state', location.state);
 
   const handleDisplayList = useCallback(() => {
     setDisplayOptions((prev) => !prev);

--- a/my-app/src/routes/Router.jsx
+++ b/my-app/src/routes/Router.jsx
@@ -27,8 +27,8 @@ function Router() {
         <Route path='/home' element={<Home />} />
         <Route path='/location' element={<Location />} />
         <Route path='/post' element={<Post />} />
-        <Route path='/post/:postId' element={<PostDetail />} />
-        <Route path='/post/:postId/edit' element={<PostEdit />} />
+        <Route path='/post/:id' element={<PostDetail />} />
+        <Route path='/post/edit' element={<PostEdit />} />
         <Route path='/upload' element={<PostUpload />} />
         <Route path='/likeposts' element={<LikePosts />} />
         <Route path='/mypage' element={<MyPage />} />

--- a/my-app/src/routes/Router.jsx
+++ b/my-app/src/routes/Router.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Hashtag from '../pages/Hashtag';
 import HashtagResult from '../pages/Hashtag/HashtagResult';
-import Home from '../pages/Home/Home';
+import Home from '../pages/Home';
 import LikePosts from '../pages/LikePosts/';
 import Login from '../pages/Login';
 import Location from '../pages/Location';


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 메인 페이지 라우터 기능, firebase 데이터 불러오기 

### 🙏🏻 기대 결과
- 각 카테고리별 메뉴 클릭하면 /post로 이동하며 클릭한 메뉴 상태 정보 전달
- firebase 데이터 받아와서 메뉴 개수 출력 및 유저 닉네임 정보 출력 

### 📸 스크린샷
<img width="258" alt="스크린샷 2023-03-13 18 49 23" src="https://user-images.githubusercontent.com/95897068/224666243-db4cef51-1763-46f1-b8bd-4e27d41e3b68.png">


### 🙂 전달사항

카테고리별 개수가 잘못 기입되는 오류가 간혹 있는데, 데이터 불러오는 방식을 변경할 듯해 일단 push합니다 추후 해결해보겠습니다 ! 

해당 작업하며 겪은 사항들 기술노트 작성하였습니다 - git pull / git reset/ 내가 보려고 쓰는 파이어베이스 / ESlint unused var Error / useNavigate 

<img width="470" alt="스크린샷 2023-03-13 18 52 26" src="https://user-images.githubusercontent.com/95897068/224666990-510db904-8d90-4858-a94f-679c5d909461.png">

### 😉 Issue Number
close : #54
