### PR TITLE
[Feat] 로그인/회원 가입 페이지_회원 가입 처리 중 버튼 비활성화 기능 구현

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,19 +1,24 @@
 import React, { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { onAuthStateChanged } from 'firebase/auth';
-import { authState, isLoggedIn } from './atom/authRecoil';
+import { authState, isAuthReady, isLoggedIn } from './atom/authRecoil';
 import Router from './routes/Router';
 import { appAuth, firestore } from './firebase';
 
 function App() {
   const [userState, setUserState] = useRecoilState(authState);
   // const setAuth = useSetRecoilState(authState);
+  const setIsAuthReady = useSetRecoilState(isAuthReady);
   const setIsLoggedIn = useSetRecoilState(isLoggedIn);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
       setUserState(user);
-      setIsLoggedIn(true);
+      setIsAuthReady(true);
+
+      if (user) {
+        setIsLoggedIn(true);
+      }
     });
 
     return unsubscribe;

--- a/my-app/src/atom/authRecoil.js
+++ b/my-app/src/atom/authRecoil.js
@@ -6,9 +6,14 @@ const authState = atom({
   dangerouslyAllowMutability: true,
 });
 
+const isAuthReady = atom({
+  key: 'isAuthReady',
+  default: false,
+});
+
 const isLoggedIn = atom({
   key: 'isLoggedIn',
   default: false,
 });
 
-export { authState, isLoggedIn };
+export { authState, isAuthReady, isLoggedIn };

--- a/my-app/src/components/common/InputWithLabel.jsx
+++ b/my-app/src/components/common/InputWithLabel.jsx
@@ -25,16 +25,20 @@ export const Input = styled.input`
     color: ${Theme.PLACEHOLDER};
   }
 
-  ${({ inputValid, isLoginAllow }) => borderState(inputValid, isLoginAllow)}
+  ${({ inputValid, isLoginAllow, alreadyError }) =>
+    borderState(inputValid, isLoginAllow, alreadyError)}
 `;
 
-function borderState(inputValid, isLoginAllow) {
+function borderState(inputValid, isLoginAllow, alreadyError) {
   if (inputValid === false) {
     return css`
       border-bottom: 1px solid ${Theme.ERROR};
     `;
-  }
-  if (isLoginAllow === false) {
+  } else if (isLoginAllow === false) {
+    return css`
+      border-bottom: 1px solid ${Theme.ERROR};
+    `;
+  } else if (alreadyError) {
     return css`
       border-bottom: 1px solid ${Theme.ERROR};
     `;
@@ -69,6 +73,8 @@ const InputWithLabel = forwardRef(
       inputValid,
       errorMessage,
       isLoginAllow,
+      alreadyError,
+      alreadyErrorMessage,
     },
     ref,
   ) => (
@@ -83,11 +89,13 @@ const InputWithLabel = forwardRef(
         onBlur={onBlur}
         ref={ref}
         inputValid={inputValid}
+        alreadyError={alreadyError}
         isLoginAllow={isLoginAllow}
         maxLength='30'
         required
       />
       {!inputValid && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      {alreadyErrorMessage && <ErrorMessage>{alreadyErrorMessage}</ErrorMessage>}
       {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </InputContainer>
   ),

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -12,7 +12,7 @@ function Login() {
   const [isLoginAllow, setIsLoginAllow] = useState(null);
   const [loginError, setLoginError] = useState('');
   const [btnDisabled, setBtnDisabled] = useState(true);
-  const { error, login } = useLogin();
+  const { error, isPending, login } = useLogin();
   const emailRef = useRef(null);
 
   const handleEmailChange = useCallback((e) => {
@@ -51,15 +51,6 @@ function Login() {
     }
   }, [email, password]);
 
-  useEffect(() => {
-    if (error) {
-      setBtnDisabled(true);
-      setIsLoginAllow(false);
-      setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
-      emailRef.current.focus();
-    }
-  }, [error]);
-
   const handleLoginSubmit = useCallback(
     (e) => {
       e.preventDefault();
@@ -67,6 +58,17 @@ function Login() {
     },
     [email, password],
   );
+
+  useEffect(() => {
+    if (error) {
+      setBtnDisabled(true);
+      setIsLoginAllow(false);
+      setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
+      emailRef.current.focus();
+    }else if(isPending) {
+      setBtnDisabled(true);
+    }
+  }, [error, isPending]);
 
   return (
     <S.Container>

--- a/my-app/src/pages/SignUp/index.jsx
+++ b/my-app/src/pages/SignUp/index.jsx
@@ -8,8 +8,8 @@ import useSignup from '../../hooks/useSignup';
 function SignUp() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [displayName, setDisplayName] = useState('');
   const [passwordCheck, setPasswordCheck] = useState('');
+  const [displayName, setDisplayName] = useState('');
 
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
@@ -25,6 +25,9 @@ function SignUp() {
   const { error, isPending, signup } = useSignup();
   const emailRef = useRef(null);
 
+  const [alreadyError, setAlreadyError] = useState(false);
+  const [alreadyErrorMessage, setAlreadyErrorMessage] = useState('');
+
   useEffect(() => {
     if (isEmailValid && isPasswordValid && isPasswordCheckValid && isDisplayNameValid) {
       setBtnDisabled(false);
@@ -35,28 +38,40 @@ function SignUp() {
 
   useEffect(() => {
     if (error) {
-      setIsEmailValid(false);
-      setBtnDisabled(true);
-      setEmailError('이미 가입된 이메일입니다.');
+      setAlreadyError(true);
+      setAlreadyErrorMessage('이미 가입된 이메일입니다.');
       emailRef.current.focus();
-    } else if (isPending) {
+    }
+  }, [error]);
+
+  useEffect(() => {
+    if (isPending) {
       setBtnDisabled(true);
-    }
-  }, [error, isPending]);
-
-  const handleEmailChange = useCallback((e) => {
-    setEmail(e.target.value);
-    const emailRegExp =
-      /^[A-Za-z0-9_]+[A-Za-z0-9]*[@]{1}[A-Za-z0-9]+[A-Za-z0-9]*[.]{1}[A-Za-z]{2,3}$/;
-
-    if (!emailRegExp.test(e.target.value)) {
-      setIsEmailValid(false);
-      setEmailError('이메일 형식이 올바르지 않습니다.');
     } else {
-      setIsEmailValid(true);
-      setEmailError(null);
+      setBtnDisabled(false);
     }
-  }, []);
+  }, [isPending]);
+
+  const handleEmailChange = useCallback(
+    (e) => {
+      setEmail(e.target.value);
+      const emailRegExp =
+        /^[A-Za-z0-9_]+[A-Za-z0-9]*[@]{1}[A-Za-z0-9]+[A-Za-z0-9]*[.]{1}[A-Za-z]{2,3}$/;
+
+      if (!emailRegExp.test(e.target.value)) {
+        setIsEmailValid(false);
+        setEmailError('이메일 형식이 올바르지 않습니다.');
+      } else {
+        setIsEmailValid(true);
+        setEmailError(null);
+      }
+
+      if (error) {
+        setEmailError(null);
+      }
+    },
+    [error],
+  );
 
   const handlePasswordChange = useCallback((e) => {
     setPassword(e.target.value);
@@ -99,12 +114,19 @@ function SignUp() {
     }
   }, []);
 
-  const handleEmailRequired = useCallback((e) => {
-    if (e.target.value === '') {
-      setIsEmailValid(false);
-      setEmailError('필수 입력 항목입니다.');
-    }
-  }, []);
+  const handleEmailRequired = useCallback(
+    (e) => {
+      if (e.target.value === '') {
+        setIsEmailValid(false);
+        setEmailError('필수 입력 항목입니다.');
+      }
+
+      if (error) {
+        setEmailError(null);
+      }
+    },
+    [error],
+  );
 
   const handlePasswordRequired = useCallback((e) => {
     if (e.target.value === '') {
@@ -154,6 +176,8 @@ function SignUp() {
             ref={emailRef}
             inputValid={isEmailValid}
             errorMessage={emailError}
+            alreadyError={alreadyError}
+            alreadyErrorMessage={alreadyErrorMessage}
           />
           <InputWithLabel
             id='userPw'

--- a/my-app/src/pages/SignUp/index.jsx
+++ b/my-app/src/pages/SignUp/index.jsx
@@ -22,7 +22,7 @@ function SignUp() {
   const [isDisplayNameValid, setIsDisplayNameValid] = useState(null);
 
   const [btnDisabled, setBtnDisabled] = useState(true);
-  const { error, signup } = useSignup();
+  const { error, isPending, signup } = useSignup();
   const emailRef = useRef(null);
 
   useEffect(() => {
@@ -39,8 +39,10 @@ function SignUp() {
       setBtnDisabled(true);
       setEmailError('이미 가입된 이메일입니다.');
       emailRef.current.focus();
+    } else if (isPending) {
+      setBtnDisabled(true);
     }
-  }, [error]);
+  }, [error, isPending]);
 
   const handleEmailChange = useCallback((e) => {
     setEmail(e.target.value);


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 로그인/회원 가입 처리 중 가입 버튼 비활성화 되도록 구현
회원 가입 시도할 때 이메일이 이미 가입된 계정일 경우 다음 회원 가입 성공까지 에러 보더와 메세지 계속 유지되도록 코드 수정
- [ ] 스타일 : 
- [x] 리팩토링 :  isLoggedIn 정보가 틀려서 코드 수정
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 로그인/회원 가입 처리 중 로그인과 가입 버튼 비활성화됨
- 회원 가입 시도할 때 이메일이 이미 가입된 계정일 경우 다음 회원 가입 성공까지 에러 보더와 메세지 계속 유지되도록 코드 수정

### 📸 스크린샷
![로그인버튼비활성화](https://user-images.githubusercontent.com/83122749/225517474-cbddeb16-6844-46f8-95fc-79fc2e5c0da0.gif)
![회원가입에러보더수정](https://user-images.githubusercontent.com/83122749/225517502-d939d3f5-95ff-49a5-953a-ce616d10961b.gif)

### 🙂 전달사항
코드 더 단순화할 수 있다면 추후 리팩토링 할 예정

### 😉 Issue Number
close : #67
