### PR TITLE
[Feat] 게시글 리스트 페이지_주요 기능 구현 

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -22,6 +22,7 @@
         "recoil": "^0.7.6",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.5",
+        "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -16690,6 +16691,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17843,9 +17852,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -30764,6 +30773,13 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "source-list-map": {
@@ -31619,9 +31635,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -17,6 +17,7 @@
     "recoil": "^0.7.6",
     "styled-components": "^5.3.6",
     "styled-reset": "^4.4.5",
+    "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/my-app/src/components/common/PostCard.jsx
+++ b/my-app/src/components/common/PostCard.jsx
@@ -124,15 +124,12 @@ const Tag = styled.span`
   }
 `;
 
-function PostCard() {
+function PostCard({ date, like, location, menu, photo, review, score, shop, tag }) {
   return (
     <PostCardBox>
       <PostCover>
-        <span>02.01</span>
-        <img
-          src='https://raw.githubusercontent.com/christianB053/likelion/develop/coffee-2139592_960_720.jpg'
-          alt='메뉴 썸네일 사진'
-        />
+        <span>{date.slice(5)}</span>
+        <img src={photo} alt='메뉴 썸네일 사진' />
       </PostCover>
       <PostContent>
         <PostInfo>
@@ -146,15 +143,14 @@ function PostCard() {
             <img src={IconStarOn} alt='별점' />
             <img src={IconStarOn} alt='별점' />
           </StarRatingContainer>
-          <MenuInfo>촉촉한 쇼콜라퐁당</MenuInfo>
-          <StoreInfo>상호명 스벅 송파점</StoreInfo>
+          <MenuInfo>{menu}</MenuInfo>
+          <StoreInfo>
+            {shop}
+            {location}
+          </StoreInfo>
         </PostInfo>
         <PostReview>
-          <p>
-            각급 선거관리위원회는 선거인명부의 작성등 선거사무와 국민투표사무에 관하여 관계
-            행정기관에 필요한 지시를 할 수 있다. 정부는 예산에 변경을 가할 필요가 있을 때에는
-            추가경정예산안을
-          </p>
+          <p>{review}</p>
           <TagContainer>
             <Tag to='#'>#넘맛탱</Tag>
             <Tag to='#'>#넘맛탱구리</Tag>

--- a/my-app/src/components/common/PostCard.jsx
+++ b/my-app/src/components/common/PostCard.jsx
@@ -4,7 +4,7 @@ import Theme from '../../styles/Theme';
 import IconHeartOff from '../../assets/Icon-Heart-off.png';
 import IconStarOn from '../../assets/Icon-star-on.png';
 
-const PostCardBox = styled.div`
+const PostCardBox = styled.li`
   position: relative;
   display: flex;
   width: 100%;

--- a/my-app/src/components/common/PostCard.jsx
+++ b/my-app/src/components/common/PostCard.jsx
@@ -128,7 +128,7 @@ function PostCard({ date, like, location, menu, photo, review, score, shop, tag 
   return (
     <PostCardBox>
       <PostCover>
-        <span>{date.slice(5)}</span>
+        <span>{date && date.slice(5)}</span>
         <img src={photo} alt='메뉴 썸네일 사진' />
       </PostCover>
       <PostContent>
@@ -145,8 +145,7 @@ function PostCard({ date, like, location, menu, photo, review, score, shop, tag 
           </StarRatingContainer>
           <MenuInfo>{menu}</MenuInfo>
           <StoreInfo>
-            {shop}
-            {location}
+            {shop}&nbsp;{location}
           </StoreInfo>
         </PostInfo>
         <PostReview>

--- a/my-app/src/firebase.js
+++ b/my-app/src/firebase.js
@@ -1,6 +1,7 @@
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/firestore';
 import 'firebase/compat/auth';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_API_KEY,
@@ -12,11 +13,14 @@ const firebaseConfig = {
 };
 
 // firebaseConfig 정보로 firebase 시작
-firebase.initializeApp(firebaseConfig);
+const app = firebase.initializeApp(firebaseConfig);
 
 // firebase의 firestore 인스턴스를 변수에 저장
 const firestore = firebase.firestore();
 const appAuth = firebase.auth();
 
+// firebaseConfig 적용하여 firestore 인스턴스 불러오기
+const db = getFirestore(app);
+
 // 필요한 곳에서 사용할 수 있도록 내보내기
-export { firestore, appAuth };
+export { firestore, appAuth, db };

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -1,0 +1,16 @@
+import { getDocs, collection, query, where } from 'firebase/firestore'; // eslint-disable-line no-unused-vars
+import { firestore, db } from '../firebase'; // eslint-disable-line no-unused-vars
+
+async function getPost() {
+  console.log(db);
+
+  const postSnapshot = await getDocs(collection(db, 'post'));
+
+  console.log(postSnapshot);
+
+  postSnapshot.forEach((doc) => {
+    console.log(doc.id, '=>', doc.data());
+  });
+}
+
+export default getPost;

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -1,10 +1,12 @@
-import { getDocs, collection } from 'firebase/firestore';
+import { getDocs, query, collection, where } from 'firebase/firestore';
 import { db } from '../firebase';
 
 // 재사용 가능하도록 디벨롭 예정
 
-async function getPost() {
-  const postSnapshot = await getDocs(collection(db, 'post'));
+async function getPost(categoryTitle) {
+  const q = query(collection(db, 'post'), where('theme', '==', categoryTitle));
+
+  const postSnapshot = await getDocs(q);
   const postList = [];
 
   postSnapshot.forEach((doc) => {

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -9,7 +9,11 @@ async function getPost() {
 
   postSnapshot.forEach((doc) => {
     console.log(doc.id, '=>', doc.data());
-    postList.push(doc.data());
+    let data = doc.data();
+
+    data = { ...data, ...{ key: doc.id } };
+
+    postList.push(data);
   });
 
   console.log(postList);

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -3,8 +3,8 @@ import { db } from '../firebase';
 
 // 재사용 가능하도록 디벨롭 예정
 
-async function getPost(categoryTitle) {
-  const q = query(collection(db, 'post'), where('theme', '==', categoryTitle));
+async function getPost(keyOption, target) {
+  const q = query(collection(db, 'post'), where(keyOption, '==', target));
 
   const postSnapshot = await getDocs(q);
   const postList = [];

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -1,16 +1,19 @@
-import { getDocs, collection, query, where } from 'firebase/firestore'; // eslint-disable-line no-unused-vars
-import { firestore, db } from '../firebase'; // eslint-disable-line no-unused-vars
+import { getDocs, collection } from 'firebase/firestore';
+import { db } from '../firebase';
+
+// 재사용 가능하도록 디벨롭 예정
 
 async function getPost() {
-  console.log(db);
-
   const postSnapshot = await getDocs(collection(db, 'post'));
-
-  console.log(postSnapshot);
+  const postList = [];
 
   postSnapshot.forEach((doc) => {
     console.log(doc.id, '=>', doc.data());
+    postList.push(doc.data());
   });
+
+  console.log(postList);
+  return postList;
 }
 
 export default getPost;

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -10,7 +10,7 @@ import NavBar from '../../components/common/NavBar';
 import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard';
-import PostCard from '../../components/common/PostCard';
+// import PostCard from '../../components/common/PostCard';
 
 function Home() {
   const [userState, setUserState] = useRecoilState(authState);
@@ -96,11 +96,7 @@ function Home() {
         </section>
         <section>
           <S.SubTitle>최근 추가된 기록</S.SubTitle>
-          <S.Cards>
-            <PostCard />
-            <PostCard />
-            <PostCard />
-          </S.Cards>
+          <S.Cards>PostCard 컴포넌트</S.Cards>
         </section>
       </S.Container>
       <NavBar page='home' />

--- a/my-app/src/pages/Home/style.js
+++ b/my-app/src/pages/Home/style.js
@@ -93,15 +93,8 @@ export const CategoryContainer = styled.div`
   gap: 2.2rem;
 `;
 
-export const Cards = styled.div`
+export const Cards = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
-`;
-
-export const Card = styled.div`
-  width: 100%;
-  height: 18.4rem;
-  border: 1px solid black;
-  border-radius: 1rem;
 `;

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
@@ -14,20 +14,18 @@ function Post() {
   const [postList, setPostList] = useState([]);
   const [btnStyle, setBtnStyle] = useState('');
 
-  const menuRef = useRef({});
-
   const categoryContents = [
-    { menuName: '전체', active: false },
-    { menuName: '커피', active: false },
-    { menuName: '논커피', active: false },
-    { menuName: '주스', active: false },
-    { menuName: '기타', active: false },
+    { categoryName: '전체', active: false },
+    { categoryName: '커피', active: false },
+    { categoryName: '논커피', active: false },
+    { categoryName: '주스', active: false },
+    { categoryName: '기타', active: false },
   ];
 
   const location = useLocation();
   const ThemeTitle = location.state;
 
-  const onClickMenu = (카테고리명) => {
+  const onClickCategory = (카테고리명) => {
     setBtnStyle(카테고리명);
 
     // 예외처리하기
@@ -70,9 +68,9 @@ function Post() {
         <nav>
           <S.CategoryContainer>
             {categoryContents.map((content, i) => (
-              <li onClick={() => onClickMenu(`${content.menuName}`, i)} key={uuidv4()}>
-                <S.CategoryBtn isActive={content.menuName === btnStyle}>
-                  {content.menuName}
+              <li onClick={() => onClickCategory(`${content.categoryName}`, i)} key={uuidv4()}>
+                <S.CategoryBtn isActive={content.categoryName === btnStyle}>
+                  {content.categoryName}
                 </S.CategoryBtn>
               </li>
             ))}

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useLocation } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
@@ -12,20 +12,35 @@ function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
   const [postList, setPostList] = useState([]);
+  const [btnStyle, setBtnStyle] = useState('');
+
+  const menuRef = useRef({});
 
   const categoryContents = [
-    { menuName: '전체' },
-    { menuName: '커피' },
-    { menuName: '논커피' },
-    { menuName: '주스' },
-    { menuName: '기타' },
+    { menuName: '전체', active: false },
+    { menuName: '커피', active: false },
+    { menuName: '논커피', active: false },
+    { menuName: '주스', active: false },
+    { menuName: '기타', active: false },
   ];
 
   const location = useLocation();
-  const categoryTitle = location.state;
+  const ThemeTitle = location.state;
+
+  const onClickMenu = (카테고리명) => {
+    setBtnStyle(카테고리명);
+
+    // 예외처리하기
+    if (카테고리명 === '전체') {
+      getPost('theme', ThemeTitle).then((data) => setPostList(data));
+    } else {
+      // 해당 카테고리명 docs 불러옴
+      getPost('category', 카테고리명).then((data) => setPostList(data));
+    }
+  };
 
   useEffect(() => {
-    getPost(categoryTitle).then((data) => setPostList(data));
+    getPost('theme', ThemeTitle).then((data) => setPostList(data));
   }, []);
 
   const handleDisplayList = useCallback(() => {
@@ -41,7 +56,7 @@ function Post() {
   return (
     <>
       <Header
-        title={categoryTitle}
+        title={ThemeTitle}
         rightChild={
           <S.HeaderBtn>
             <img src={IconSearch} alt='검색' />
@@ -50,13 +65,15 @@ function Post() {
       />
       <S.Container>
         <header>
-          <h1 className='ir'>{categoryTitle} 게시글 페이지</h1>
+          <h1 className='ir'>{ThemeTitle} 게시글 페이지</h1>
         </header>
         <nav>
           <S.CategoryContainer>
-            {categoryContents.map((content) => (
-              <li key={uuidv4()}>
-                <S.CategoryBtn>{content.menuName}</S.CategoryBtn>
+            {categoryContents.map((content, i) => (
+              <li onClick={() => onClickMenu(`${content.menuName}`, i)} key={uuidv4()}>
+                <S.CategoryBtn isActive={content.menuName === btnStyle}>
+                  {content.menuName}
+                </S.CategoryBtn>
               </li>
             ))}
           </S.CategoryContainer>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -72,24 +72,7 @@ function Post() {
           </S.ListBox>
         </S.SelectBox>
         <S.PostContainer>
-          <li>
-            <PostCard />
-          </li>
-          <li>
-            <PostCard />
-          </li>
-          <li>
-            <PostCard />
-          </li>
-          <li>
-            <PostCard />
-          </li>
-          <li>
-            <PostCard />
-          </li>
-          <li>
-            <PostCard />
-          </li>
+          <PostCard />
         </S.PostContainer>
       </S.Container>
       <NavBar />

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -44,6 +44,7 @@ function Post() {
   };
 
   useEffect(() => {
+    setBtnStyle('전체');
     getPost('theme', ThemeTitle).then((data) => setPostList(data));
   }, []);
 

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router';
+import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import IconSearch from '../../assets/Icon-Search.png';
@@ -54,26 +55,10 @@ function Post() {
         <nav>
           <S.CategoryContainer>
             {categoryContents.map((content) => (
-              <li>
+              <li key={uuidv4()}>
                 <S.CategoryBtn>{content.menuName}</S.CategoryBtn>
               </li>
             ))}
-
-            {/* <li>
-              <S.CategoryBtn>전체</S.CategoryBtn>
-            </li>
-            <li>
-              <S.CategoryBtn>커피</S.CategoryBtn>
-            </li>
-            <li>
-              <S.CategoryBtn>논커피</S.CategoryBtn>
-            </li>
-            <li>
-              <S.CategoryBtn>주스</S.CategoryBtn>
-            </li>
-            <li>
-              <S.CategoryBtn>기타</S.CategoryBtn>
-            </li> */}
           </S.CategoryContainer>
         </nav>
         <S.SelectBox onClick={handleDisplayList} options={displayOptions}>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -12,6 +12,14 @@ function Post() {
   const [displayOptions, setDisplayOptions] = useState(false);
   const [postList, setPostList] = useState([]);
 
+  const categoryContents = [
+    { menuName: '전체' },
+    { menuName: '커피' },
+    { menuName: '논커피' },
+    { menuName: '주스' },
+    { menuName: '기타' },
+  ];
+
   const location = useLocation();
   const categoryTitle = location.state;
 
@@ -45,7 +53,13 @@ function Post() {
         </header>
         <nav>
           <S.CategoryContainer>
-            <li>
+            {categoryContents.map((content) => (
+              <li>
+                <S.CategoryBtn>{content.menuName}</S.CategoryBtn>
+              </li>
+            ))}
+
+            {/* <li>
               <S.CategoryBtn>전체</S.CategoryBtn>
             </li>
             <li>
@@ -59,7 +73,7 @@ function Post() {
             </li>
             <li>
               <S.CategoryBtn>기타</S.CategoryBtn>
-            </li>
+            </li> */}
           </S.CategoryContainer>
         </nav>
         <S.SelectBox onClick={handleDisplayList} options={displayOptions}>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -8,33 +8,38 @@ import PostCard from '../../components/common/PostCard';
 import * as S from './style';
 import getPost from '../../hooks/getPost';
 
+const categoryContentsAll = [
+  {
+    Theme: '음료',
+    categories: ['전체', '커피', '논커피', '주스', '기타'],
+  },
+  {
+    Theme: '디저트',
+    categories: [],
+  },
+];
+
 function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
   const [postList, setPostList] = useState([]);
   const [btnStyle, setBtnStyle] = useState('');
 
-  const categoryContents = [
-    { categoryName: '전체', active: false },
-    { categoryName: '커피', active: false },
-    { categoryName: '논커피', active: false },
-    { categoryName: '주스', active: false },
-    { categoryName: '기타', active: false },
-  ];
-
   const location = useLocation();
   const navigate = useNavigate();
   const ThemeTitle = location.state;
 
-  const onClickCategory = (카테고리명) => {
-    setBtnStyle(카테고리명);
+  const categoryContents = categoryContentsAll.filter((v) => v.Theme === ThemeTitle)[0];
+
+  const onClickCategory = (categoryName) => {
+    setBtnStyle(categoryName);
 
     // 예외처리하기
-    if (카테고리명 === '전체') {
+    if (categoryName === '전체') {
       getPost('theme', ThemeTitle).then((data) => setPostList(data));
     } else {
-      // 해당 카테고리명 docs 불러옴
-      getPost('category', 카테고리명).then((data) => setPostList(data));
+      // 해당 categoryName docs 불러옴
+      getPost('category', categoryName).then((data) => setPostList(data));
     }
   };
 
@@ -68,11 +73,9 @@ function Post() {
         </header>
         <nav>
           <S.CategoryContainer>
-            {categoryContents.map((content, i) => (
-              <li onClick={() => onClickCategory(`${content.categoryName}`, i)} key={uuidv4()}>
-                <S.CategoryBtn isActive={content.categoryName === btnStyle}>
-                  {content.categoryName}
-                </S.CategoryBtn>
+            {categoryContents.categories.map((content, i) => (
+              <li onClick={() => onClickCategory(`${content}`)} key={uuidv4()}>
+                <S.CategoryBtn isActive={content === btnStyle}>{content}</S.CategoryBtn>
               </li>
             ))}
           </S.CategoryContainer>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router';
+
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import IconSearch from '../../assets/Icon-Search.png';
@@ -9,10 +10,16 @@ import * as S from './style';
 function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
+  const [categoryTitle, setCategoryTitle] = useState('');
 
   const location = useLocation();
 
   console.log('state', location.state);
+
+  useEffect(() => {
+    setCategoryTitle(location.state);
+    console.log(categoryTitle);
+  }, []);
 
   const handleDisplayList = useCallback(() => {
     setDisplayOptions((prev) => !prev);
@@ -27,7 +34,7 @@ function Post() {
   return (
     <>
       <Header
-        title='음료props'
+        title={categoryTitle}
         rightChild={
           <S.HeaderBtn>
             <img src={IconSearch} alt='검색' />
@@ -36,7 +43,7 @@ function Post() {
       />
       <S.Container>
         <header>
-          <h1 className='ir'>음료/props 게시글 페이지</h1>
+          <h1 className='ir'>{categoryTitle} 게시글 페이지</h1>
         </header>
         <nav>
           <S.CategoryContainer>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,20 +1,30 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router';
 
+import { getDoc, doc } from 'firebase/firestore/lite'; // eslint-disable-line no-unused-vars
+import { collection, query, where, getDocs } from 'firebase/firestore'; // eslint-disable-line no-unused-vars
+import { db, firestore } from '../../firebase'; // eslint-disable-line no-unused-vars
+
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import IconSearch from '../../assets/Icon-Search.png';
 import PostCard from '../../components/common/PostCard';
 import * as S from './style';
+import getPost from '../../hooks/getPost';
 
 function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
   const [categoryTitle, setCategoryTitle] = useState('');
+  const [postList, setPostList] = useState([]); // eslint-disable-line no-unused-vars
+
+  useEffect(() => {
+    console.log('useEffect 작동');
+
+    getPost();
+  }, []);
 
   const location = useLocation();
-
-  console.log('state', location.state);
 
   useEffect(() => {
     setCategoryTitle(location.state);

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,10 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router';
-
-import { getDoc, doc } from 'firebase/firestore/lite'; // eslint-disable-line no-unused-vars
-import { collection, query, where, getDocs } from 'firebase/firestore'; // eslint-disable-line no-unused-vars
-import { db, firestore } from '../../firebase'; // eslint-disable-line no-unused-vars
-
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import IconSearch from '../../assets/Icon-Search.png';
@@ -19,9 +14,7 @@ function Post() {
   const [postList, setPostList] = useState([]); // eslint-disable-line no-unused-vars
 
   useEffect(() => {
-    console.log('useEffect 작동');
-
-    getPost();
+    getPost().then((data) => setPostList(data));
   }, []);
 
   const location = useLocation();

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -10,18 +10,13 @@ import getPost from '../../hooks/getPost';
 function Post() {
   const [currentOrder, setCurrentOrder] = useState('최신순');
   const [displayOptions, setDisplayOptions] = useState(false);
-  const [categoryTitle, setCategoryTitle] = useState('');
-  const [postList, setPostList] = useState([]); // eslint-disable-line no-unused-vars
-
-  useEffect(() => {
-    getPost().then((data) => setPostList(data));
-  }, []);
+  const [postList, setPostList] = useState([]);
 
   const location = useLocation();
+  const categoryTitle = location.state;
 
   useEffect(() => {
-    setCategoryTitle(location.state);
-    console.log(categoryTitle);
+    getPost(categoryTitle).then((data) => setPostList(data));
   }, []);
 
   const handleDisplayList = useCallback(() => {
@@ -75,7 +70,20 @@ function Post() {
           </S.ListBox>
         </S.SelectBox>
         <S.PostContainer>
-          <PostCard />
+          {postList.map((post) => (
+            <PostCard
+              key={post.key}
+              date={post.date}
+              like={post.like}
+              location={post.location}
+              menu={post.menu}
+              photo={post.photo}
+              review={post.review}
+              score={post.score}
+              shop={post.shop}
+              tag={post.tag}
+            />
+          ))}
         </S.PostContainer>
       </S.Container>
       <NavBar />

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation, Navigate, useNavigate } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -23,6 +23,7 @@ function Post() {
   ];
 
   const location = useLocation();
+  const navigate = useNavigate();
   const ThemeTitle = location.state;
 
   const onClickCategory = (카테고리명) => {
@@ -56,7 +57,7 @@ function Post() {
       <Header
         title={ThemeTitle}
         rightChild={
-          <S.HeaderBtn>
+          <S.HeaderBtn onClick={() => navigate('/search')}>
             <img src={IconSearch} alt='검색' />
           </S.HeaderBtn>
         }

--- a/my-app/src/pages/Post/style.js
+++ b/my-app/src/pages/Post/style.js
@@ -15,14 +15,10 @@ export const CategoryContainer = styled.ul`
 `;
 
 export const CategoryBtn = styled.button`
-  color: ${Theme.MAIN_GRAY};
+  color: ${({ isActive }) => (isActive ? `${Theme.MAIN_FONT}` : `${Theme.MAIN_GRAY}`)};
+
   font-family: 'LINESeedKR-Bd';
   font-size: 1.4rem;
-
-  &:hover,
-  &:active {
-    color: ${Theme.MAIN_FONT};
-  }
 `;
 
 export const SelectBox = styled.div`


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 게시글 리스트 페이지 주요 기능 구현 


### 🙏🏻 기대 결과
- 메인 페이지에서 음료 / 디저트 선택 시 해당 테마로 이동한다.
- 이동과 동시에 useLocation으로 상태를 전달해, 음료 / 디저트 각각 테마에 해당하는 post들을 읽어온다.
- 포스트를 읽어오는 함수는 getPost.js로 hook 폴더 내부에 구현하였으며 재사용성을 최대한 확보하고자 하였다.
- 리스트 형식의 key 생성을 위한 라이브러리 uuidv4를 설치하였다. 
- 각 테마 안에서 하위 카테고리 메뉴는 객체화하여, 이후 디저트의 하위 카테고리가 늘어날 경우 추가가 용이하도록 설계하였다. 

### 📸 스크린샷

<img width="310" alt="스크린샷 2023-03-18 00 38 33" src="https://user-images.githubusercontent.com/95897068/225951499-4bf8d8f4-8fbf-4495-9f87-5634d4b9b701.png">
<img width="310" alt="스크린샷 2023-03-18 00 38 44" src="https://user-images.githubusercontent.com/95897068/225951541-e980a48b-e2b1-42cb-bc23-508b047abe4f.png">

<img width="310" alt="스크린샷 2023-03-18 00 38 57" src="https://user-images.githubusercontent.com/95897068/225951603-480e7712-9cbf-423a-8973-c71209e5e25d.png">


### 🙂 전달사항
firebase.js 안에 코드를 조금 변경하였습니다! 

<img width="437" alt="스크린샷 2023-03-18 00 56 47" src="https://user-images.githubusercontent.com/95897068/225955820-0564cb39-3289-4ee4-8371-ccba54601013.png">

추후 음료나 디저트의 하위 카테고리가 늘어난다면 Post 페이지의 배열에 문자열만 추가해주면 됩니다. 

### 😉 Issue Number
close : #69
