### PR TITLE
[Feat] 메인 페이지_post 최신순 불러오기 기능

### DIFF
--- a/my-app/src/components/common/PostCard.jsx
+++ b/my-app/src/components/common/PostCard.jsx
@@ -128,7 +128,7 @@ function PostCard({ date, like, location, menu, photo, review, score, shop, tag 
   return (
     <PostCardBox>
       <PostCover>
-        <span>{date && date.slice(5)}</span>
+        <span>01.00</span>
         <img src={photo} alt='메뉴 썸네일 사진' />
       </PostCover>
       <PostContent>

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -1,7 +1,7 @@
-import { getDocs, query, collection, where } from 'firebase/firestore';
+import { getDocs, query, collection, where, orderBy } from 'firebase/firestore';
 import { db } from '../firebase';
 
-async function getPost(keyOption, target) {
+async function getPost(queryOption, target, option) {
   const postList = [];
   const q = query(collection(db, 'post'));
 
@@ -16,15 +16,22 @@ async function getPost(keyOption, target) {
     });
   };
 
-  if (keyOption === 'ALL') {
+  if (queryOption === 'ALL') {
     const postSnapshot = await getDocs(q);
 
     getData(postSnapshot);
+  } else if (queryOption === 'ORDER_BY') {
+    const postSnapshot = await getDocs(query(q, orderBy(target, option)));
+
+    console.log('orderby', postSnapshot);
+
+    getData(postSnapshot);
   } else {
-    const postSnapshot = await getDocs(query(q, where(keyOption, '==', target)));
+    const postSnapshot = await getDocs(query(q, where(queryOption, '==', target)));
 
     getData(postSnapshot);
   }
+
   console.log(postList);
   return postList;
 }

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -1,10 +1,9 @@
 import { getDocs, query, collection, where } from 'firebase/firestore';
 import { db } from '../firebase';
 
-// 재사용 가능하도록 디벨롭 예정
-
 async function getPost(keyOption, target) {
   const postList = [];
+  const q = query(collection(db, 'post'));
 
   const getData = (postSnapshot) => {
     postSnapshot.forEach((doc) => {
@@ -18,20 +17,16 @@ async function getPost(keyOption, target) {
   };
 
   if (keyOption === 'ALL') {
-    const q = query(collection(db, 'post'));
     const postSnapshot = await getDocs(q);
 
     getData(postSnapshot);
-    console.log(postList);
-    return postList;
   } else {
-    const q = query(collection(db, 'post'), where(keyOption, '==', target));
-    const postSnapshot = await getDocs(q);
+    const postSnapshot = await getDocs(query(q, where(keyOption, '==', target)));
 
     getData(postSnapshot);
-    console.log(postList);
-    return postList;
   }
+  console.log(postList);
+  return postList;
 }
 
 export default getPost;

--- a/my-app/src/hooks/getPost.js
+++ b/my-app/src/hooks/getPost.js
@@ -4,22 +4,34 @@ import { db } from '../firebase';
 // 재사용 가능하도록 디벨롭 예정
 
 async function getPost(keyOption, target) {
-  const q = query(collection(db, 'post'), where(keyOption, '==', target));
-
-  const postSnapshot = await getDocs(q);
   const postList = [];
 
-  postSnapshot.forEach((doc) => {
-    console.log(doc.id, '=>', doc.data());
-    let data = doc.data();
+  const getData = (postSnapshot) => {
+    postSnapshot.forEach((doc) => {
+      console.log(doc.id, '=>', doc.data());
+      let data = doc.data();
 
-    data = { ...data, ...{ key: doc.id } };
+      data = { ...data, ...{ key: doc.id } };
 
-    postList.push(data);
-  });
+      postList.push(data);
+    });
+  };
 
-  console.log(postList);
-  return postList;
+  if (keyOption === 'ALL') {
+    const q = query(collection(db, 'post'));
+    const postSnapshot = await getDocs(q);
+
+    getData(postSnapshot);
+    console.log(postList);
+    return postList;
+  } else {
+    const q = query(collection(db, 'post'), where(keyOption, '==', target));
+    const postSnapshot = await getDocs(q);
+
+    getData(postSnapshot);
+    console.log(postList);
+    return postList;
+  }
 }
 
 export default getPost;

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -10,7 +10,7 @@ import NavBar from '../../components/common/NavBar';
 import DrinkIcon from '../../assets/Icon-beverage.png';
 import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard';
-// import PostCard from '../../components/common/PostCard';
+import PostCard from '../../components/common/PostCard';
 
 import getPost from '../../hooks/getPost';
 
@@ -20,6 +20,8 @@ function Home() {
   const [postCount, setPostCount] = useState(0);
   const [drinkCount, setDrinkCount] = useState(0);
   const [dessertCount, setDessertCount] = useState(0);
+
+  const [recentPosts, setRecentPosts] = useState([]);
 
   const cards = [
     {
@@ -53,7 +55,13 @@ function Home() {
       setDrinkCount(data.filter((v) => v.theme === '음료').length);
       setDessertCount(data.filter((v) => v.theme === '디저트').length);
     });
-  });
+  }, []);
+
+  useEffect(() => {
+    getPost('ORDER_BY', 'createAt', 'desc').then((data) => {
+      setRecentPosts(data.slice(0, 3));
+    });
+  }, []);
 
   return (
     <>
@@ -91,7 +99,21 @@ function Home() {
         </section>
         <section>
           <S.SubTitle>최근 추가된 기록</S.SubTitle>
-          <S.Cards>PostCard 컴포넌트</S.Cards>
+          <S.Cards>
+            {recentPosts.map((post) => (
+              <PostCard
+                key={post.key}
+                date={post.date}
+                like={post.like}
+                location={post.location}
+                menu={post.menu}
+                photo={post.photo}
+                review={post.review}
+                score={post.score}
+                shop={post.shop}
+              />
+            ))}
+          </S.Cards>
         </section>
       </S.Container>
       <NavBar page='home' />

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { onAuthStateChanged } from 'firebase/auth';
 import { authState } from '../../atom/authRecoil';
-import { appAuth, firestore } from '../../firebase';
+import { appAuth } from '../../firebase';
 
 import * as S from './style';
 import Header from '../../components/common/Header';
@@ -12,12 +12,14 @@ import DessertIcon from '../../assets/Icon-dessert.png';
 import CategoryCard from '../../components/home/CategoryCard';
 // import PostCard from '../../components/common/PostCard';
 
+import getPost from '../../hooks/getPost';
+
 function Home() {
   const [userState, setUserState] = useRecoilState(authState);
   const [userName, setUserName] = useState('');
-  const [postCount, setPostCount] = useState();
+  const [postCount, setPostCount] = useState(0);
   const [drinkCount, setDrinkCount] = useState(0);
-  const [dessertCount, setdessertCount] = useState(0);
+  const [dessertCount, setDessertCount] = useState(0);
 
   const cards = [
     {
@@ -46,19 +48,14 @@ function Home() {
   }, [setUserState]);
 
   useEffect(() => {
-    firestore
-      .collection('post')
-      .get()
-      .then((result) => {
-        result.forEach((doc) => {
-          setPostCount(doc.data.length);
-          doc.data().theme === '음료'
-            ? setDrinkCount(drinkCount + 1)
-            : setdessertCount(dessertCount + 1);
-        });
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    getPost('theme', '음료').then((data) => setDrinkCount(data.length));
+
+    getPost('theme', '디저트').then((data) => setDessertCount(data.length));
   }, []);
+
+  useEffect(() => {
+    setPostCount(drinkCount + dessertCount);
+  }, [drinkCount, dessertCount]);
 
   return (
     <>

--- a/my-app/src/pages/Home/index.jsx
+++ b/my-app/src/pages/Home/index.jsx
@@ -48,14 +48,12 @@ function Home() {
   }, [setUserState]);
 
   useEffect(() => {
-    getPost('theme', '음료').then((data) => setDrinkCount(data.length));
-
-    getPost('theme', '디저트').then((data) => setDessertCount(data.length));
-  }, []);
-
-  useEffect(() => {
-    setPostCount(drinkCount + dessertCount);
-  }, [drinkCount, dessertCount]);
+    getPost('ALL').then((data) => {
+      setPostCount(data.length);
+      setDrinkCount(data.filter((v) => v.theme === '음료').length);
+      setDessertCount(data.filter((v) => v.theme === '디저트').length);
+    });
+  });
 
   return (
     <>

--- a/my-app/src/pages/Post/index.jsx
+++ b/my-app/src/pages/Post/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation, Navigate, useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 메인 페이지 - 최근 게시글 보여주는 기능 추가
- [x] 리팩토링 : getPost.js 성능 개선 (orderby 기능 추가)


### 🙏🏻 기대 결과
- 메인 페이지 기능 완성

### 📸 스크린샷
<img width="308" alt="스크린샷 2023-03-20 19 20 57" src="https://user-images.githubusercontent.com/95897068/226311792-22f42114-0a66-4618-87ac-1a42783e0de0.png">

최대 3개 보여집니다.

### 🙂 전달사항

<img width="816" alt="스크린샷 2023-03-20 19 21 44" src="https://user-images.githubusercontent.com/95897068/226311978-1ca622bd-08db-4d15-8265-2538f8fc4f22.png">

구현 중 기술노트에 코드 개선과정 기록해놓았습니다. 

디스코드에도 안내되었지만 createAt 속성이 추가되었고 
기존의 날짜 관련 속성들이 timestamp로 변경된 점 테스트 데이터에도 반영하여 구현하였습니다.

### 😉 Issue Number
close : #74 
