### PR TITLE
[Feat] 좋아요 페이지_기능 구현

### DIFF
--- a/my-app/src/components/hashtag/HashtagResultView/index.jsx
+++ b/my-app/src/components/hashtag/HashtagResultView/index.jsx
@@ -8,6 +8,7 @@ function HashtagResultView({ postList }) {
       {postList.map((post) => (
         <PostCard
           key={post.key}
+          id={post.key}
           date={post.date}
           like={post.like}
           location={post.location}
@@ -17,6 +18,7 @@ function HashtagResultView({ postList }) {
           score={post.score}
           shop={post.shop}
           tags={post.tag}
+          postList={postList}
         />
       ))}
     </Cards>

--- a/my-app/src/components/post/PostCard/index.jsx
+++ b/my-app/src/components/post/PostCard/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { deleteDoc, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import * as S from './style';
 
 import { db } from '../../../firebase';
@@ -10,12 +10,16 @@ import IconHeartOff from '../../../assets/Icon-Heart-off.png';
 import IconStarOn from '../../../assets/Icon-star-on.png';
 import IconStarOff from '../../../assets/Icon-star-off.png';
 import useToggle from '../../../hooks/useToggle';
+import Portal from '../../modal/Portal';
+import ConfirmModal from '../../modal/ConfirmModal';
 
 function PostCard({ id, date, like, location, menu, photo, review, score, shop, tags, postList }) {
   const scoreIndexs = [0, 1, 2, 3, 4];
   const [liked, setLiked] = useToggle(like);
   const [formattedDate, setFormattedDate] = useState();
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useToggle();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   const formatDate = (dateFormatted) => {
     const dateString = dateFormatted.toISOString();
@@ -49,9 +53,18 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
   };
 
   const handleLikeButton = (e) => {
-    setLiked(!liked);
-    updatePost(id, !liked);
-    e.stopPropagation();
+    if (pathname === '/likeposts') {
+      e.stopPropagation();
+      setIsConfirmModalOpen();
+    } else {
+      setLiked(!liked);
+      updatePost(id, !liked);
+      e.stopPropagation();
+    }
+  };
+
+  const confirmModalClose = () => {
+    setIsConfirmModalOpen();
   };
 
   const handleClickCard = () => {
@@ -61,47 +74,60 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
   };
 
   return (
-    <S.PostCardBox onClick={handleClickCard}>
-      <S.PostCover>
-        <span>{formattedDate}</span>
-        {photo && <img src={photo} alt='메뉴 썸네일 사진' />}
-      </S.PostCover>
-      <S.PostContent>
-        <S.PostInfo>
-          <S.PostLike onClick={handleLikeButton}>
-            {liked ? (
-              <img src={IconHeartOn} alt='좋아요 표시' />
-            ) : (
-              <img src={IconHeartOff} alt='좋아요 표시하지 않음' />
-            )}
-          </S.PostLike>
-          <S.StarRatingContainer>
-            {scoreIndexs.map((index) =>
-              score > index ? (
-                <img src={IconStarOn} alt='별점' key={index} />
+    <>
+      <S.PostCardBox onClick={handleClickCard}>
+        <S.PostCover>
+          <span>{formattedDate}</span>
+          {photo && <img src={photo} alt='메뉴 썸네일 사진' />}
+        </S.PostCover>
+        <S.PostContent>
+          <S.PostInfo>
+            <S.PostLike onClick={handleLikeButton}>
+              {liked ? (
+                <img src={IconHeartOn} alt='좋아요 표시' />
               ) : (
-                <img src={IconStarOff} alt='체크되지 않은 별점' aria-hidden='true' key={index} />
-              ),
-            )}
-          </S.StarRatingContainer>
-          <S.MenuInfo>{menu}</S.MenuInfo>
-          <S.StoreInfo>
-            {shop}&nbsp;{location}
-          </S.StoreInfo>
-        </S.PostInfo>
-        <S.PostReview>
-          {review && <p>{review}</p>}
-          <S.TagContainer>
-            {tags &&
-              tags.map((tag) => (
-                <S.Tag to='#' key={uuidv4()}>
-                  #{tag}
-                </S.Tag>
-              ))}
-          </S.TagContainer>
-        </S.PostReview>
-      </S.PostContent>
-    </S.PostCardBox>
+                <img src={IconHeartOff} alt='좋아요 표시하지 않음' />
+              )}
+            </S.PostLike>
+            <S.StarRatingContainer>
+              {scoreIndexs.map((index) =>
+                score > index ? (
+                  <img src={IconStarOn} alt='별점' key={index} />
+                ) : (
+                  <img src={IconStarOff} alt='체크되지 않은 별점' aria-hidden='true' key={index} />
+                ),
+              )}
+            </S.StarRatingContainer>
+            <S.MenuInfo>{menu}</S.MenuInfo>
+            <S.StoreInfo>
+              {shop}&nbsp;{location}
+            </S.StoreInfo>
+          </S.PostInfo>
+          <S.PostReview>
+            {review && <p>{review}</p>}
+            <S.TagContainer>
+              {tags &&
+                tags.map((tag) => (
+                  <S.Tag to='#' key={uuidv4()}>
+                    #{tag}
+                  </S.Tag>
+                ))}
+            </S.TagContainer>
+          </S.PostReview>
+        </S.PostContent>
+      </S.PostCardBox>
+      <Portal>
+        <ConfirmModal
+          visible={isConfirmModalOpen}
+          msg='좋아요 목록에서 삭제할까요?'
+          leftBtnMsg='취소'
+          rightBtnMsg='삭제'
+          onClickClose={confirmModalClose}
+          rightOnclick={() => console.log('삭제 클릭')}
+          leftOnclick={confirmModalClose}
+        />
+      </Portal>
+    </>
   );
 }
 

--- a/my-app/src/components/post/PostCard/index.jsx
+++ b/my-app/src/components/post/PostCard/index.jsx
@@ -28,10 +28,6 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
     setFormattedDate(slicedDate);
   };
 
-  console.log('pathname', pathname);
-  console.log('postList', postList);
-
-
   useEffect(() => {
     const dateFormatted = date.toDate();
 

--- a/my-app/src/components/post/PostCard/index.jsx
+++ b/my-app/src/components/post/PostCard/index.jsx
@@ -123,7 +123,7 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
           leftBtnMsg='취소'
           rightBtnMsg='삭제'
           onClickClose={confirmModalClose}
-          rightOnclick={() => console.log('삭제 클릭')}
+          rightOnclick={() => updatePost(id, !liked)}
           leftOnclick={confirmModalClose}
         />
       </Portal>

--- a/my-app/src/components/post/PostCard/index.jsx
+++ b/my-app/src/components/post/PostCard/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { doc, updateDoc } from 'firebase/firestore';
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
 import { useNavigate } from 'react-router';
 import * as S from './style';
@@ -35,6 +35,17 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
     const newField = { like: newLiked };
 
     await updateDoc(postDoc, newField);
+
+    if (newLiked) {
+      const postData = (await getDoc(postDoc)).data();
+
+      await setDoc(doc(db, 'liked', id), {
+        ...postData,
+        like: newLiked,
+      });
+    } else {
+      await deleteDoc(doc(db, 'liked', id));
+    }
   };
 
   const handleLikeButton = (e) => {

--- a/my-app/src/components/post/PostCard/index.jsx
+++ b/my-app/src/components/post/PostCard/index.jsx
@@ -28,6 +28,10 @@ function PostCard({ id, date, like, location, menu, photo, review, score, shop, 
     setFormattedDate(slicedDate);
   };
 
+  console.log('pathname', pathname);
+  console.log('postList', postList);
+
+
   useEffect(() => {
     const dateFormatted = date.toDate();
 

--- a/my-app/src/components/search/SearchPost/SearchResultView/index.jsx
+++ b/my-app/src/components/search/SearchPost/SearchResultView/index.jsx
@@ -8,6 +8,7 @@ function SearchResultView({ postList }) {
       {postList.map((post) => (
         <PostCard
           key={post.key}
+          id={post.key}
           date={post.date}
           like={post.like}
           location={post.location}
@@ -17,6 +18,7 @@ function SearchResultView({ postList }) {
           score={post.score}
           shop={post.shop}
           tags={post.tag}
+          postList={postList}
         />
       ))}
     </Cards>

--- a/my-app/src/pages/LikePosts/DefaultLikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/DefaultLikePosts/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as S from './style';
+import IconBeverage from '../../../assets/Icon-beverage.png';
+
+export default function DefaultLikePosts() {
+  return (
+    <S.Container>
+      <header>
+        <h1 className='ir'>좋아요 게시글 페이지</h1>
+      </header>
+      <div>
+        <img src={IconBeverage} alt='' />
+      </div>
+      <p>등록된 게시글이 없어요.</p>
+    </S.Container>
+  );
+}

--- a/my-app/src/pages/LikePosts/DefaultLikePosts/style.js
+++ b/my-app/src/pages/LikePosts/DefaultLikePosts/style.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const Container = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, calc(-50% - 6px));
+
+  img {
+    width: 8rem;
+  }
+
+  p {
+    margin-top: 0.5rem;
+    font-size: 1.8rem;
+  }
+`;
+
+export default Container;

--- a/my-app/src/pages/LikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/index.jsx
@@ -8,6 +8,7 @@ import * as S from './style';
 import { authState } from '../../atom/authRecoil';
 import { db } from '../../firebase';
 import PostCard from '../../components/post/PostCard';
+import DefaultLikePosts from './DefaultLikePosts';
 
 function LikePosts() {
   const user = useRecoilValue(authState);
@@ -45,7 +46,7 @@ function LikePosts() {
           <h1 className='ir'>좋아요 게시글 페이지</h1>
         </header>
         <S.LikedPostContainer>
-          {likedPostList &&
+          {likedPostList.length > 0 ? (
             likedPostList.map((post) => (
               <PostCard
                 key={uuidv4()}
@@ -61,7 +62,10 @@ function LikePosts() {
                 tags={post.tag}
                 postList={likedPostList}
               />
-            ))}
+            ))
+          ) : (
+            <DefaultLikePosts />
+          )}
         </S.LikedPostContainer>
       </S.Container>
       <NavBar />

--- a/my-app/src/pages/LikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/index.jsx
@@ -7,7 +7,12 @@ function LikePosts() {
   return (
     <>
       <Header title='좋아요' />
-      <S.Container>카드 컴포넌트</S.Container>
+      <S.Container>
+        <header>
+          <h1 className='ir'>좋아요 게시글 페이지</h1>
+        </header>
+        <S.LikedPostContainer>좋아요 게시글</S.LikedPostContainer>
+      </S.Container>
       <NavBar />
     </>
   );

--- a/my-app/src/pages/LikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/index.jsx
@@ -14,6 +14,7 @@ function LikePosts() {
   const user = useRecoilValue(authState);
   const likedRef = collection(db, 'liked');
   const [likedPostList, setLikedPostList] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (user) {
@@ -34,40 +35,44 @@ function LikePosts() {
 
       setLikedPostList(listArr);
     });
-  };
 
-  console.log('likedPostList', likedPostList);
+    setIsLoading(false);
+  };
 
   return (
     <>
       <Header title='좋아요' />
-      <S.Container>
-        <header>
-          <h1 className='ir'>좋아요 게시글 페이지</h1>
-        </header>
-        <S.LikedPostContainer>
-          {likedPostList.length > 0 ? (
-            likedPostList.map((post) => (
-              <PostCard
-                key={uuidv4()}
-                id={post.key}
-                date={post.createAt}
-                like={post.like}
-                location={post.address.location}
-                menu={post.menu}
-                photo={post.photo}
-                review={post.review}
-                score={post.score}
-                shop={post.shop}
-                tags={post.tag}
-                postList={likedPostList}
-              />
-            ))
-          ) : (
-            <DefaultLikePosts />
-          )}
-        </S.LikedPostContainer>
-      </S.Container>
+      {isLoading ? (
+        <p style={{ marginTop: '5.2rem' }}>로딩중...임시</p>
+      ) : (
+        <S.Container>
+          <header>
+            <h1 className='ir'>좋아요 게시글 페이지</h1>
+          </header>
+          <S.LikedPostContainer>
+            {likedPostList.length > 0 ? (
+              likedPostList.map((post) => (
+                <PostCard
+                  key={uuidv4()}
+                  id={post.key}
+                  date={post.createAt}
+                  like={post.like}
+                  location={post.address.location}
+                  menu={post.menu}
+                  photo={post.photo}
+                  review={post.review}
+                  score={post.score}
+                  shop={post.shop}
+                  tags={post.tag}
+                  postList={likedPostList}
+                />
+              ))
+            ) : (
+              <DefaultLikePosts />
+            )}
+          </S.LikedPostContainer>
+        </S.Container>
+      )}
       <NavBar />
     </>
   );

--- a/my-app/src/pages/LikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/index.jsx
@@ -1,9 +1,40 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import * as S from './style';
+import { authState } from '../../atom/authRecoil';
+import { db } from '../../firebase';
 
 function LikePosts() {
+  const user = useRecoilValue(authState);
+  const likedRef = collection(db, 'liked');
+  const [likedPostList, setLikedPostList] = useState([]);
+
+  useEffect(() => {
+    if (user) {
+      addLikedListener();
+    }
+  }, [user]);
+
+  const addLikedListener = () => {
+    const q = query(likedRef, where('uid', '==', user.uid));
+
+    onSnapshot(q, (querySnapshot) => {
+      const listArr = [];
+
+      querySnapshot.forEach((doc) => {
+        listArr.push({ ...doc.data(), key: doc.id });
+      });
+      listArr.sort((a, b) => b.createAt.seconds - a.createAt.seconds);
+
+      setLikedPostList(listArr);
+    });
+  };
+
+  console.log('likedPostList', likedPostList);
+
   return (
     <>
       <Header title='좋아요' />

--- a/my-app/src/pages/LikePosts/index.jsx
+++ b/my-app/src/pages/LikePosts/index.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { v4 as uuidv4 } from 'uuid';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
 import * as S from './style';
 import { authState } from '../../atom/authRecoil';
 import { db } from '../../firebase';
+import PostCard from '../../components/post/PostCard';
 
 function LikePosts() {
   const user = useRecoilValue(authState);
@@ -42,7 +44,25 @@ function LikePosts() {
         <header>
           <h1 className='ir'>좋아요 게시글 페이지</h1>
         </header>
-        <S.LikedPostContainer>좋아요 게시글</S.LikedPostContainer>
+        <S.LikedPostContainer>
+          {likedPostList &&
+            likedPostList.map((post) => (
+              <PostCard
+                key={uuidv4()}
+                id={post.key}
+                date={post.createAt}
+                like={post.like}
+                location={post.address.location}
+                menu={post.menu}
+                photo={post.photo}
+                review={post.review}
+                score={post.score}
+                shop={post.shop}
+                tags={post.tag}
+                postList={likedPostList}
+              />
+            ))}
+        </S.LikedPostContainer>
       </S.Container>
       <NavBar />
     </>

--- a/my-app/src/pages/LikePosts/style.js
+++ b/my-app/src/pages/LikePosts/style.js
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.main`
   padding: 4.8rem 0 6rem;
 `;
 
-export default Container;
+export const LikedPostContainer = styled.ul`
+  padding: 2.6rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;

--- a/my-app/src/pages/Post/PostDetail/index.jsx
+++ b/my-app/src/pages/Post/PostDetail/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { updateDoc, doc, deleteField, onSnapshot, deleteDoc } from 'firebase/firestore';
+import { useRecoilState } from 'recoil';
+import { updateDoc, doc, onSnapshot, deleteDoc, setDoc } from 'firebase/firestore';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../../../firebase';
@@ -17,7 +17,6 @@ import IconHeartOff from '../../../assets/Icon-Heart-off.png';
 import IconHeartOn from '../../../assets/Icon-Heart-on.png';
 import IconMore from '../../../assets/Icon-More.png';
 import currentPost from '../../../atom/currentPostRecoil';
-import { authState } from '../../../atom/authRecoil';
 import SimpleSlider from '../../../components/post/SimpleSlider';
 import modalState from '../../../atom/modalRecoil';
 import Portal from '../../../components/modal/Portal';
@@ -27,7 +26,6 @@ import ConfirmModal from '../../../components/modal/ConfirmModal';
 import useToggle from '../../../hooks/useToggle';
 
 function PostDetail() {
-  const user = useRecoilValue(authState);
   const { id } = useParams();
   const postRef = doc(db, 'post', id);
   const [post, setPost] = useRecoilState(currentPost);
@@ -107,15 +105,14 @@ function PostDetail() {
       await updateDoc(postRef, {
         like: false,
       });
-      await updateDoc(doc(db, 'liked', user.uid), {
-        [id]: deleteField(),
-      });
+      await deleteDoc(doc(db, 'liked', id));
     } else {
       await updateDoc(postRef, {
         like: true,
       });
-      await updateDoc(doc(db, 'liked', user.uid), {
-        [id]: { ...post, like: true },
+      await setDoc(doc(db, 'liked', id), {
+        ...post,
+        like: true,
       });
     }
   };


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 :  
- liked 컬렉션에 저장된 문서들을 불러옴
- 좋아요 페이지에서 좋아요 버튼 클릭 시 모달창 뜸
- 모달창에서 삭제 버튼 클릭 시 해당 좋아요 게시글은 좋아요 리스트에서 제외됨
- [ ] 스타일 : 
- [x] 리팩토링 : 좋아요 버튼 클릭 시 기존 liked/uid/postId로 저장되던 방식을 liked/postId로 저장되도록 수정
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 

### 📸 스크린샷
![좋아요페이지](https://user-images.githubusercontent.com/83122749/233249679-d2962ffc-48f4-49d4-96e3-67ec395baf8a.gif)


### 🙂 전달사항
- 로딩 페이지 만들어지기 전이라 임시로 '로딩 중' 문구 넣었습니다.

### 😉 Issue Number
close : #119
