### PR TITLE
[Feat] 공통 페이지_로그인 여부에 따른 페이지 이동 구현

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -13,12 +13,15 @@ function App() {
   // const setAuth = useSetRecoilState(authState);
   const setIsAuthReady = useSetRecoilState(isAuthReady);
   const setIsLoggedIn = useSetRecoilState(isLoggedIn);
+  const [isLoading, setIsLoading] = useState(false);
 
   const [userId, setUserId] = useRecoilState(UserIdState);
 
   useEffect(() => {
+    setIsLoading(true);
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
       setUserState(user);
+      setIsLoading(false);
       setIsAuthReady(true);
       setUserId(user.uid);
       console.log(userId);
@@ -45,6 +48,10 @@ function App() {
         console.log(doc.id);
       });
   });
+
+  if(isLoading) {
+    return <p style={{marginTop:'6.8rem', fontSize:'3rem'}}>로딩 중 임시</p>
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -13,21 +13,19 @@ function App() {
   // const setAuth = useSetRecoilState(authState);
   const setIsAuthReady = useSetRecoilState(isAuthReady);
   const setIsLoggedIn = useSetRecoilState(isLoggedIn);
-  const [isLoading, setIsLoading] = useState(false);
 
   const [userId, setUserId] = useRecoilState(UserIdState);
 
   useEffect(() => {
-    setIsLoading(true);
     const unsubscribe = onAuthStateChanged(appAuth, (user) => {
       setUserState(user);
-      setIsLoading(false);
       setIsAuthReady(true);
-      setUserId(user.uid);
-      console.log(userId);
 
       if (user) {
+        setUserId(user.uid);
         setIsLoggedIn(true);
+      } else {
+        setIsLoggedIn(false);
       }
     });
 
@@ -35,6 +33,7 @@ function App() {
   }, []);
 
   console.log('authState', userState);
+  console.log(userId);
 
   useEffect(() => {
     console.log(firestore);
@@ -48,10 +47,6 @@ function App() {
         console.log(doc.id);
       });
   });
-
-  if(isLoading) {
-    return <p style={{marginTop:'6.8rem', fontSize:'3rem'}}>로딩 중 임시</p>
-  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/my-app/src/atom/authRecoil.js
+++ b/my-app/src/atom/authRecoil.js
@@ -13,7 +13,7 @@ const isAuthReady = atom({
 
 const isLoggedIn = atom({
   key: 'isLoggedIn',
-  default: false,
+  default: null,
 });
 
 const UserIdState = atom({

--- a/my-app/src/hooks/useLogin.js
+++ b/my-app/src/hooks/useLogin.js
@@ -1,6 +1,6 @@
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useSetRecoilState } from 'recoil';
 import { authState } from '../atom/authRecoil';
 import { appAuth } from '../firebase';
@@ -10,6 +10,8 @@ export default function useLogin() {
   const [isPending, setIsPending] = useState(false);
   const setAuth = useSetRecoilState(authState);
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || '/home';
 
   const login = (email, password) => {
     setError(null);
@@ -22,7 +24,7 @@ export default function useLogin() {
         setAuth(user);
         setError(null);
         setIsPending(false);
-        navigate('/home');
+        navigate(from);
 
         if (!user) {
           throw new Error('로그인에 실패했습니다.');

--- a/my-app/src/hooks/useSignup.js
+++ b/my-app/src/hooks/useSignup.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { setDoc, doc } from 'firebase/firestore';
 import { appAuth, firestore } from '../firebase.js';
 import { authState } from '../atom/authRecoil.js';
@@ -11,6 +11,8 @@ const useSignup = () => {
   const [isPending, setIsPending] = useState(false);
   const setAuth = useSetRecoilState(authState);
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || '/home';
 
   const signup = (email, password, displayName) => {
     setError(null);
@@ -30,7 +32,7 @@ const useSignup = () => {
             setAuth(user);
             setError(null);
             setIsPending(false);
-            navigate('/home');
+            navigate(from);
 
             await setDoc(doc(firestore, 'users', uid), {
               uid,

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import * as S from './style';
 import Button from '../../components/common/Button';
 import InputWithLabel from '../../components/common/InputWithLabel';
@@ -19,12 +19,10 @@ function Login() {
   const emailRef = useRef(null);
   const isLogin = useRecoilValue(isLoggedIn);
   const navigate = useNavigate();
-  const location = useLocation();
-  const from = location.state?.from?.pathname || '/home';
 
   useEffect(() => {
     if (isLogin) {
-      navigate(from);
+      navigate('/home');
     }
   }, [isLogin]);
 

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -1,8 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useNavigate } from 'react-router';
 import * as S from './style';
 import Button from '../../components/common/Button';
 import InputWithLabel from '../../components/common/InputWithLabel';
 import useLogin from '../../hooks/useLogin';
+import { isLoggedIn } from '../../atom/authRecoil';
 
 function Login() {
   const [email, setEmail] = useState('');
@@ -14,6 +17,8 @@ function Login() {
   const [btnDisabled, setBtnDisabled] = useState(true);
   const { error, isPending, login } = useLogin();
   const emailRef = useRef(null);
+  const isLogin = useRecoilValue(isLoggedIn);
+  const navigate = useNavigate();
 
   const handleEmailChange = useCallback((e) => {
     setEmail(e.target.value);
@@ -65,10 +70,16 @@ function Login() {
       setIsLoginAllow(false);
       setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
       emailRef.current.focus();
-    }else if(isPending) {
+    } else if (isPending) {
       setBtnDisabled(true);
     }
   }, [error, isPending]);
+
+  useEffect(() => {
+    if (isLogin) {
+      navigate('/home');
+    }
+  }, [isLogin]);
 
   return (
     <S.Container>

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -20,6 +20,36 @@ function Login() {
   const isLogin = useRecoilValue(isLoggedIn);
   const navigate = useNavigate();
 
+  useEffect(() => {
+    if (isLogin) {
+      navigate('/home');
+    }
+  }, [isLogin]);
+
+  useEffect(() => {
+    if (isEmailValid && isPasswordValid) {
+      setBtnDisabled(false);
+      setIsLoginAllow(true);
+
+      if (error) {
+        setIsLoginAllow(false);
+      }
+    } else {
+      setBtnDisabled(true);
+    }
+  }, [email, password]);
+
+  useEffect(() => {
+    if (error) {
+      setBtnDisabled(true);
+      setIsLoginAllow(false);
+      setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
+      emailRef.current.focus();
+    } else if (isPending) {
+      setBtnDisabled(true);
+    }
+  }, [error, isPending]);
+
   const handleEmailChange = useCallback((e) => {
     setEmail(e.target.value);
 
@@ -43,19 +73,6 @@ function Login() {
     }
   }, []);
 
-  useEffect(() => {
-    if (isEmailValid && isPasswordValid) {
-      setBtnDisabled(false);
-      setIsLoginAllow(true);
-
-      if (error) {
-        setIsLoginAllow(false);
-      }
-    } else {
-      setBtnDisabled(true);
-    }
-  }, [email, password]);
-
   const handleLoginSubmit = useCallback(
     (e) => {
       e.preventDefault();
@@ -63,23 +80,6 @@ function Login() {
     },
     [email, password],
   );
-
-  useEffect(() => {
-    if (error) {
-      setBtnDisabled(true);
-      setIsLoginAllow(false);
-      setLoginError('이메일 또는 비밀번호가 일치하지 않습니다.');
-      emailRef.current.focus();
-    } else if (isPending) {
-      setBtnDisabled(true);
-    }
-  }, [error, isPending]);
-
-  useEffect(() => {
-    if (isLogin) {
-      navigate('/home');
-    }
-  }, [isLogin]);
 
   return (
     <S.Container>

--- a/my-app/src/pages/Login/index.jsx
+++ b/my-app/src/pages/Login/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import * as S from './style';
 import Button from '../../components/common/Button';
 import InputWithLabel from '../../components/common/InputWithLabel';
@@ -19,10 +19,12 @@ function Login() {
   const emailRef = useRef(null);
   const isLogin = useRecoilValue(isLoggedIn);
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || '/home';
 
   useEffect(() => {
     if (isLogin) {
-      navigate('/home');
+      navigate(from);
     }
   }, [isLogin]);
 

--- a/my-app/src/pages/MyPage/index.jsx
+++ b/my-app/src/pages/MyPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAuth, signOut } from 'firebase/auth';
+import { useSetRecoilState } from 'recoil';
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -8,12 +9,14 @@ import Button from '../../components/common/Button';
 import ConfirmModal from '../../components/modal/ConfirmModal';
 import Portal from '../../components/modal/Portal';
 import useToggle from '../../hooks/useToggle';
+import { isLoggedIn } from '../../atom/authRecoil';
 
 function MyPage() {
   const [isModalOpen, setIsModalOpen] = useToggle();
   const navigate = useNavigate();
   const auth = getAuth();
   const [user, setUser] = useState(null);
+  const setIsLoggedIn = useSetRecoilState(isLoggedIn);
 
   useEffect(() => {
     const currentUser = auth.currentUser;
@@ -28,6 +31,7 @@ function MyPage() {
 
   const onLogOutClick = () => {
     signOut(auth);
+    setIsLoggedIn(false);
     navigate('/login');
   };
   const onCancelClick = () => {

--- a/my-app/src/pages/MyPage/index.jsx
+++ b/my-app/src/pages/MyPage/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAuth, signOut } from 'firebase/auth';
-import { useSetRecoilState } from 'recoil';
 import * as S from './style';
 import Header from '../../components/common/Header';
 import NavBar from '../../components/common/NavBar';
@@ -9,14 +8,12 @@ import Button from '../../components/common/Button';
 import ConfirmModal from '../../components/modal/ConfirmModal';
 import Portal from '../../components/modal/Portal';
 import useToggle from '../../hooks/useToggle';
-import { isLoggedIn } from '../../atom/authRecoil';
 
 function MyPage() {
   const [isModalOpen, setIsModalOpen] = useToggle();
   const navigate = useNavigate();
   const auth = getAuth();
   const [user, setUser] = useState(null);
-  const setIsLoggedIn = useSetRecoilState(isLoggedIn);
 
   useEffect(() => {
     const currentUser = auth.currentUser;
@@ -31,7 +28,6 @@ function MyPage() {
 
   const onLogOutClick = () => {
     signOut(auth);
-    setIsLoggedIn(false);
     navigate('/login');
   };
   const onCancelClick = () => {

--- a/my-app/src/pages/SignUp/index.jsx
+++ b/my-app/src/pages/SignUp/index.jsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useRecoilValue } from 'recoil';
 import * as S from './style';
 import Button from '../../components/common/Button';
 import Header from '../../components/common/Header';
 import InputWithLabel from '../../components/common/InputWithLabel';
 import useSignup from '../../hooks/useSignup';
+import { isLoggedIn } from '../../atom/authRecoil';
 
 function SignUp() {
   const [email, setEmail] = useState('');
@@ -27,6 +30,15 @@ function SignUp() {
 
   const [alreadyError, setAlreadyError] = useState(false);
   const [alreadyErrorMessage, setAlreadyErrorMessage] = useState('');
+
+  const isLogin = useRecoilValue(isLoggedIn);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLogin) {
+      navigate('/home');
+    }
+  }, [isLogin]);
 
   useEffect(() => {
     if (isEmailValid && isPasswordValid && isPasswordCheckValid && isDisplayNameValid) {

--- a/my-app/src/routes/ProtectRoute.jsx
+++ b/my-app/src/routes/ProtectRoute.jsx
@@ -7,6 +7,10 @@ export default function ProtectedRoute() {
   const isLogin = useRecoilValue(isLoggedIn);
   const location = useLocation();
 
+  if (isLogin === null) {
+    return null;
+  }
+
   return isLogin ? (
     <Outlet></Outlet>
   ) : (

--- a/my-app/src/routes/ProtectRoute.jsx
+++ b/my-app/src/routes/ProtectRoute.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router';
+import { useRecoilValue } from 'recoil';
+import { isLoggedIn } from '../atom/authRecoil';
+
+export default function ProtectedRoute() {
+  const isLogin = useRecoilValue(isLoggedIn);
+  const location = useLocation();
+
+  return isLogin ? (
+    <Outlet></Outlet>
+  ) : (
+    <Navigate to={'/login'} replace state={{ from: location }} />
+  );
+}

--- a/my-app/src/routes/Router.jsx
+++ b/my-app/src/routes/Router.jsx
@@ -16,6 +16,7 @@ import PostUpload from '../pages/Post/PostUpload';
 import Search from '../pages/Search';
 import SignUp from '../pages/SignUp';
 import Splash from '../pages/Splash/Splash';
+import ProtectedRoute from './ProtectRoute';
 import Test from '../pages/Test';
 
 function Router() {
@@ -25,18 +26,20 @@ function Router() {
         <Route path='/splash' element={<Splash />} />
         <Route path='/login' element={<Login />} />
         <Route path='/signup' element={<SignUp />} />
-        <Route path='/home' element={<Home />} />
-        <Route path='/location' element={<Location />} />
-        <Route path='/post' element={<Post />} />
-        <Route path='/post/:id' element={<PostDetail />} />
-        <Route path='/post/:id/edit' element={<PostEdit />} />
-        <Route path='/upload' element={<PostUpload />} />
-        <Route path='/likeposts' element={<LikePosts />} />
-        <Route path='/mypage' element={<MyPage />} />
-        <Route path='/profile/:userId/edit' element={<ProfileEdit />} />
-        <Route path='/hashtag' element={<Hashtag />} />
-        <Route path='/hashtag/keyword' element={<HashtagResult />} />
-        <Route path='/search' element={<Search />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path='/home' element={<Home />} />
+          <Route path='/location' element={<Location />} />
+          <Route path='/post' element={<Post />} />
+          <Route path='/post/:id' element={<PostDetail />} />
+          <Route path='/post/:id/edit' element={<PostEdit />} />
+          <Route path='/upload' element={<PostUpload />} />
+          <Route path='/likeposts' element={<LikePosts />} />
+          <Route path='/mypage' element={<MyPage />} />
+          <Route path='/profile/:userId/edit' element={<ProfileEdit />} />
+          <Route path='/hashtag' element={<Hashtag />} />
+          <Route path='/hashtag/keyword' element={<HashtagResult />} />
+          <Route path='/search' element={<Search />} />
+        </Route>
         <Route path='*' element={<NotFound />} />
         <Route path='/test' element={<Test />} />
       </Routes>


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
- 로그인 정보가 있다면 home 페이지로, 로그인 정보가 없다면 login 페이지로 이동
- 로그인되어 있지 않은 상태로 home, hashtag, search 등등 페이지 접속 시 바로 로그인 페이지로 이동되고, 로그인 후에는 이전에 접속한 페이지로 다시 이동됨
(예: search 페이지 접속 -> login 페이지 이동 -> 로그인 후 다시 search 페이지로 이동)
- [ ] 스타일 : 
- [ ] 리팩토링 : 
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 

### 📸 스크린샷
![로그인여부라우터구현](https://user-images.githubusercontent.com/83122749/233853508-0b64e647-ed39-480a-91e0-5e392b4f155c.gif)


### 🙂 전달사항

### 😉 Issue Number
close : #68
