### PR TITLE
[Feat] 지도_추가기능 구현 #106

### DIFF
--- a/my-app/src/pages/Location/index.jsx
+++ b/my-app/src/pages/Location/index.jsx
@@ -10,10 +10,12 @@ import { authState } from '../../atom/authRecoil';
 function Location() {
   const user = useRecoilValue(authState);
   const [userPost, setUserPost] = useState([]);
+  const [likedPost, setLikedPost] = useState([]);
 
   useEffect(() => {
     if (user) {
       getUserData();
+      getLikedData();
     }
   }, [user]);
 
@@ -29,6 +31,17 @@ function Location() {
     setUserPost(postArr);
   };
 
+  const getLikedData = async () => {
+    const postArr = [];
+    const q = query(collection(db, 'liked'), where('uid', '==', user.uid));
+    const querySnapshot = await getDocs(q);
+
+    querySnapshot.forEach((value) => {
+      postArr.push(value.data().address.latLng);
+    });
+    setLikedPost(postArr);
+  }
+
   return (
     <>
       <Header title='지도' />
@@ -39,6 +52,17 @@ function Location() {
       >
         {userPost &&
           userPost.map((marker, index) => (
+            <MapMarker
+              key={index}
+              position={{
+                lat: `${marker[0]}`,
+                lng: `${marker[1]}`,
+              }}
+              draggable={true}
+            />
+          ))}
+        {likedPost && 
+          likedPost.map((marker, index) => (
             <MapMarker
               key={index}
               position={{


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [X] 기능 추가 :  지도페이지 추가기능 구현
- [ ] 스타일 : 
- [ ] 리팩토링 : 
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 좋아요에 있는 글의 매장 좌표를 불러와 지도 화면에 마킹됩니다.

### 📸 스크린샷
<img width="949" alt="화면 캡처 2023-04-24 173803" src="https://user-images.githubusercontent.com/53033847/233946033-34b0424c-83a8-43b0-82fc-03da71394556.png">


<img width="938" alt="화면 캡처 2023-04-24 174743" src="https://user-images.githubusercontent.com/53033847/233946493-f8edfa77-33e2-49fb-889f-f8fdf5debff8.png">

### 🙂 전달사항
- GIF로 올리기에 용량이 너무 커서 이미지로 대체합니다.
### 😉 Issue Number
close : #106 
