### PR TITLE
[Refactor] 게시글 작성 페이지_셀렉트박스 key 및 파이어베이스 업로드 value 값 변경 작업

### DIFF
--- a/my-app/src/atom/postUploadRecoil.js
+++ b/my-app/src/atom/postUploadRecoil.js
@@ -1,13 +1,13 @@
 import { atom } from 'recoil';
 import SELECTBOX_DATA from '../components/post/CategorySelectBox/SELECTBOX_DATA';
 
-const categoryState = atom({
-  key: 'categoryState',
+const themeState = atom({
+  key: 'themeState',
   default: SELECTBOX_DATA[0].name,
 });
 
-const themeState = atom({
-  key: 'themeState',
+const categoryState = atom({
+  key: 'categoryState',
   default: SELECTBOX_DATA[0].option[0].subName,
 });
 
@@ -64,8 +64,8 @@ const imageDeleteState = atom({
 });
 
 export {
-  categoryState,
   themeState,
+  categoryState,
   dateState,
   menuNameState,
   menuPriceState,

--- a/my-app/src/components/post/CategorySelectBox/index.jsx
+++ b/my-app/src/components/post/CategorySelectBox/index.jsx
@@ -13,7 +13,7 @@ function CategorySelectBox({
   subOption,
   currentSelectList,
   handleCheckTheme,
-  currentSelectTheme,
+  currentSelectCategory,
 }) {
   return (
     <S.SelectBox options={isShowOption} onClick={handleDisplay} ref={selectedRef}>
@@ -26,7 +26,7 @@ function CategorySelectBox({
               {optiondata.map((option) => (
                 <S.ListOption
                   key={option.id}
-                  onClick={() => handleCheckCategory(option.id)}
+                  onClick={() => handleCheckTheme(option.id)}
                   currentSelectList={currentSelectList}
                 >
                   {option.name}
@@ -39,8 +39,8 @@ function CategorySelectBox({
               {subOption.map((option) => (
                 <S.ListOption
                   key={option.subId}
-                  onClick={() => handleCheckTheme(option.subId)}
-                  currentSelectList={currentSelectTheme}
+                  onClick={() => handleCheckCategory(option.subId)}
+                  currentSelectList={currentSelectCategory}
                 >
                   {option.subName}
                 </S.ListOption>

--- a/my-app/src/components/post/PostForm/index.jsx
+++ b/my-app/src/components/post/PostForm/index.jsx
@@ -11,8 +11,8 @@ import { storage } from '../../../firebase';
 import { authState } from '../../../atom/authRecoil';
 import '../PostForm/datepicker.css';
 import {
-  categoryState,
   themeState,
+  categoryState,
   dateState,
   menuNameState,
   menuPriceState,
@@ -40,17 +40,17 @@ import * as S from './style';
 
 function PostForm({ editPost, edit }) {
   const { kakao } = window;
-  const [isShowOptionCategory, setIsShowOptionCategory, categoryRef, handleDisplayCategory] =
-    useOutsideDetect(false);
   const [isShowOptionTheme, setIsShowOptionTheme, themeRef, handleDisplayTheme] =
+    useOutsideDetect(false);
+  const [isShowOptionCategory, setIsShowOptionCategory, categoryRef, handleDisplayCategory] =
     useOutsideDetect(false);
 
   const [inputValid, setInputValid] = useRecoilState(inputValidState);
 
-  const [currentCategory, setCurrentCategory] = useRecoilState(categoryState);
   const [currentTheme, setCurrentTheme] = useRecoilState(themeState);
-  const [currentSelectCategory, setCurrentSelectCategory] = useState(1);
+  const [currentCategory, setCurrentCategory] = useRecoilState(categoryState);
   const [currentSelectTheme, setCurrentSelectTheme] = useState(1);
+  const [currentSelectCategory, setCurrentSelectCategory] = useState(1);
 
   const [startDate, setStartDate] = useRecoilState(dateState);
 
@@ -132,39 +132,39 @@ function PostForm({ editPost, edit }) {
     }
   }, []);
 
-  const handleClickListCategory = useCallback((e) => {
-    setCurrentCategory(e.target.innerText);
-    setCurrentTheme(
+  const handleClickListTheme = useCallback((e) => {
+    setCurrentTheme(e.target.innerText);
+    setCurrentCategory(
       e.target.innerText === '음료'
         ? SELECTBOX_DATA[0].option[0].subName
         : SELECTBOX_DATA[1].option[0].subName,
     );
-    setIsShowOptionCategory(false);
-    e.stopPropagation();
-  }, []);
-
-  const handleClickListTheme = useCallback((e) => {
-    setCurrentTheme(e.target.innerText);
     setIsShowOptionTheme(false);
     e.stopPropagation();
   }, []);
 
-  const handleCheckCategory = useCallback(
-    (id) => {
-      setCurrentSelectCategory(id);
-      setCurrentSelectTheme(1);
-    },
-    [currentSelectCategory],
-  );
+  const handleClickListCategory = useCallback((e) => {
+    setCurrentCategory(e.target.innerText);
+    setIsShowOptionCategory(false);
+    e.stopPropagation();
+  }, []);
 
   const handleCheckTheme = useCallback(
     (id) => {
       setCurrentSelectTheme(id);
+      setCurrentSelectCategory(1);
     },
     [currentSelectTheme],
   );
 
-  const subOption = SELECTBOX_DATA.find((category) => category.id === currentSelectCategory).option;
+  const handleCheckCategory = useCallback(
+    (id) => {
+      setCurrentSelectCategory(id);
+    },
+    [currentSelectCategory],
+  );
+
+  const subOption = SELECTBOX_DATA.find((category) => category.id === currentSelectTheme).option;
 
   useEffect(() => {
     if (!startDate) {
@@ -470,24 +470,24 @@ function PostForm({ editPost, edit }) {
             <CategorySelectBox
               boxValue={true}
               optiondata={SELECTBOX_DATA}
-              selectedRef={categoryRef}
-              isShowOption={isShowOptionCategory}
-              handleClickList={handleClickListCategory}
-              currentSelected={currentCategory}
-              handleDisplay={handleDisplayCategory}
-              handleCheckCategory={handleCheckCategory}
-              currentSelectList={currentSelectCategory}
-            />
-            <CategorySelectBox
-              boxValue={false}
-              subOption={subOption}
               selectedRef={themeRef}
               isShowOption={isShowOptionTheme}
               handleClickList={handleClickListTheme}
               currentSelected={currentTheme}
               handleDisplay={handleDisplayTheme}
               handleCheckTheme={handleCheckTheme}
-              currentSelectTheme={currentSelectTheme}
+              currentSelectList={currentSelectTheme}
+            />
+            <CategorySelectBox
+              boxValue={false}
+              subOption={subOption}
+              selectedRef={categoryRef}
+              isShowOption={isShowOptionCategory}
+              handleClickList={handleClickListCategory}
+              currentSelected={currentCategory}
+              handleDisplay={handleDisplayCategory}
+              handleCheckCategory={handleCheckCategory}
+              currentSelectCategory={currentSelectCategory}
             />
           </S.SelectBoxWrapper>
           <S.InputBox length='1.2rem'>

--- a/my-app/src/components/post/PostForm/index.jsx
+++ b/my-app/src/components/post/PostForm/index.jsx
@@ -82,13 +82,13 @@ function PostForm({ editPost, edit }) {
 
   useEffect(() => {
     if (edit) {
-      const currentSelectValue = SELECTBOX_DATA.find(
-        (category) => category.name === editPost?.category,
+      const currentSelectThemeValue = SELECTBOX_DATA.find(
+        (theme) => theme.name === editPost?.theme,
       )?.id;
 
-      const currentSelectThemeValue = SELECTBOX_DATA.filter(
-        (main) => main.name === editPost?.category,
-      ).map((sub) => sub.option.find((theme) => theme.subName === editPost?.theme)?.subId);
+      const currentSelectCategoryValue = SELECTBOX_DATA.filter(
+        (main) => main.name === editPost?.theme,
+      ).map((sub) => sub.option.find((category) => category.subName === editPost?.category)?.subId);
 
       if (
         editPost?.menu &&
@@ -111,10 +111,10 @@ function PostForm({ editPost, edit }) {
 
       if (editPost.tag.length > 0) setTagStyled(true);
 
-      setCurrentCategory(editPost?.category);
-      setCurrentSelectCategory(currentSelectValue);
       setCurrentTheme(editPost?.theme);
       setCurrentSelectTheme(currentSelectThemeValue);
+      setCurrentCategory(editPost?.category);
+      setCurrentSelectCategory(currentSelectCategoryValue);
       setStartDate(editPost?.date.seconds * 1000);
       setMenuName(editPost?.menu);
       setMenuPrice(editPost?.price);

--- a/my-app/src/pages/Post/PostEdit/index.jsx
+++ b/my-app/src/pages/Post/PostEdit/index.jsx
@@ -26,8 +26,8 @@ import placeState from '../../../atom/mapRecoil';
 import usePostUpload from '../../../hooks/usePostUpload';
 
 function PostEdit() {
-  const selectCategory = useRecoilValue(categoryState);
   const selectTheme = useRecoilValue(themeState);
+  const selectCategory = useRecoilValue(categoryState);
   const selectDate = useRecoilValue(dateState);
   const menuName = useRecoilValue(menuNameState);
   const menuPrice = useRecoilValue(menuPriceState);
@@ -102,8 +102,8 @@ function PostEdit() {
     const updateDate = Timestamp.fromDate(new Date(selectDate));
 
     updatePost({
-      category: selectCategory,
       theme: selectTheme,
+      category: selectCategory,
       date: updateDate,
       menu: menuName,
       price: menuPrice,

--- a/my-app/src/pages/Post/PostUpload/index.jsx
+++ b/my-app/src/pages/Post/PostUpload/index.jsx
@@ -26,8 +26,8 @@ import usePostUpload from '../../../hooks/usePostUpload';
 import useResetInput from '../../../hooks/useResetInput';
 
 function PostUpload() {
-  const selectCategory = useRecoilValue(categoryState);
   const selectTheme = useRecoilValue(themeState);
+  const selectCategory = useRecoilValue(categoryState);
   const selectDate = useRecoilValue(dateState);
   const menuName = useRecoilValue(menuNameState);
   const menuPrice = useRecoilValue(menuPriceState);
@@ -69,8 +69,8 @@ function PostUpload() {
   };
 
   const isInputValue =
-    selectCategory !== '음료' ||
-    selectTheme !== '커피' ||
+    selectTheme !== '음료' ||
+    selectCategory !== '커피' ||
     !!selectDate ||
     !!menuName ||
     !!menuPrice ||
@@ -93,8 +93,8 @@ function PostUpload() {
     e.preventDefault();
 
     addPost({
-      category: selectCategory,
       theme: selectTheme,
+      category: selectCategory,
       date: selectDate,
       menu: menuName,
       price: menuPrice,


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [X] 리팩토링 : 셀렉트박스의 key값 및 데이터(category, theme)를 파이어베이스 key값과 동일하게 변경
- [X] 버그 수정 : 서버에 업로드 시 넘겨지는 key값 데이터 수정(recoil 및 파이어베이스)

### 🙏🏻 기대 결과
- 게시글 등록 시 Home의 기록 앨범에 주제별로 개수 집계가 적용됨

### 📸 스크린샷
<img width="300" alt="스크린샷 2023-06-12 오후 8 50 37" src="https://github.com/co-diary/front/assets/104605709/7b2a7669-80b1-463e-a769-62f71dca1ebc">

### 🙂 전달사항
- postForm의 셀렉트박스와 파이어베이스의 셀렉트박스 데이터 혼동없도록 통일했습니다.

### 😉 Issue Number
close : #133
