### PR TITLE
[Fix] 게시글 작성 페이지/게시글 상세 페이지_confirm modal 버튼 오류 및 수정 페이지 이동 오류 수정

### DIFF
--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -96,7 +96,7 @@ function PostDetail() {
     navigate(`/post/${id}/edit`, {
       state: post,
     });
-  }, []);
+  }, [post]);
 
   const onClickDelete = useCallback(() => {
     setIsConfirmModalOpen({ ...isConfirmModalOpen, visible: !isConfirmModalOpen.visible });

--- a/src/pages/Post/PostEdit/index.jsx
+++ b/src/pages/Post/PostEdit/index.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useParams, useNavigate } from 'react-router';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { Timestamp } from 'firebase/firestore';
 import Header from '../../../components/common/Header';
 import NavBar from '../../../components/common/NavBar';
 import Button from '../../../components/common/Button';
 import PostForm from '../../../components/post/PostForm';
-import useToggle from '../../../hooks/useToggle';
 import Portal from '../../../components/modal/Portal';
 import ConfirmModal from '../../../components/modal/ConfirmModal';
+import { confirmModalState } from '../../../atom/modalRecoil';
 import {
   categoryState,
   themeState,
@@ -43,10 +43,12 @@ function PostEdit() {
   const { state } = useLocation();
   const { id } = useParams();
   const navigate = useNavigate();
-  const [isConfirmModalOpen, setIsConfirmModalOpen] = useToggle();
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useRecoilState(confirmModalState);
   const { updatePost, response, deleteImg } = usePostUpload('post', id);
   const [btnDisabled, setBtnDisabled] = useState(false);
   const imageDeleteList = useRecoilValue(imageDeleteState);
+
+  console.log('넘어온 state값', state);
 
   useEffect(() => {
     if (
@@ -89,11 +91,11 @@ function PostEdit() {
   }, []);
 
   const handlePostEditConfirm = () => {
-    setIsConfirmModalOpen();
+    setIsConfirmModalOpen((prev) => ({ ...prev, visible: true }));
   };
 
   const confirmModalClose = () => {
-    setIsConfirmModalOpen();
+    setIsConfirmModalOpen(false);
   };
 
   const handlePostEdit = (e) => {
@@ -139,7 +141,7 @@ function PostEdit() {
       <PostForm edit editPost={state} />
       <Portal>
         <ConfirmModal
-          visible={isConfirmModalOpen}
+          visible={isConfirmModalOpen.visible}
           msg='게시글을 등록할까요?'
           leftBtnMsg='취소'
           rightBtnMsg='등록'

--- a/src/pages/Post/PostUpload/index.jsx
+++ b/src/pages/Post/PostUpload/index.jsx
@@ -63,7 +63,7 @@ function PostUpload() {
   }, [inputValid]);
 
   const handlePostUploadConfirm = () => {
-    setIsConfirmModalOpen((prev) => !prev);
+    setIsConfirmModalOpen((prev) => ({ ...prev, visible: true }));
   };
 
   const confirmModalClose = () => {


### PR DESCRIPTION
### 👩🏻‍💻 무엇을 위한 PR인가요?
- [X] 리팩토링 :  게시글 수정페이지 ConfirmModal 전역 상태 관리로 변경
- [X] 버그 수정 : 게시글 등록 버튼 클릭시 confirm modal 보이지 않는 오류 해결, 게시글 수정 버튼 클릭시 null값 전달되는 오류 해결

### 🙏🏻 기대 결과
- 정상적인 게시글 업로드 동작
- 정상적인 게시글 수정 페이지 이동 

### 📸 스크린샷
🙌

### 🙂 전달사항
- 게시글 등록부터 상세페이지까지 모두 연결되어있어 다른 페이지도 어떤 상태인지 항상 확인이 필요한 것 같습니다!

### 😉 Issue Number
close : #141
